### PR TITLE
optional universe name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,14 +326,17 @@ impl Universe {
     /// let drain = Mutex::new(slog_term::FullFormat::new(decorator).build()).fuse();
     /// let log = slog::Logger::root(drain, o!());
     ///
-    /// // Create world with logger
-    /// let universe = Universe::new(log);
+    /// // Create universe with logger and random name
+    /// let universe = Universe::new(log, None);
     ///
-    /// // Create world without logger
-    /// let universe = Universe::new(None);
+    /// // Create universe without logger and predefined name
+    /// let universe = Universe::new(None, Some("my universe"));
     /// ```
-    pub fn new<L: Into<Option<slog::Logger>>>(logger: L) -> Self {
-        let name = names::Generator::default().next().unwrap();
+    pub fn new<L: Into<Option<slog::Logger>>>(logger: L, name: Option<&str>) -> Self {
+        let name = name
+            .map(|s| s.to_owned())
+            .unwrap_or_else(|| names::Generator::default().next().unwrap());
+
         let logger = logger
             .into()
             .unwrap_or(slog::Logger::root(slog_stdlog::StdLog.fuse(), o!()))


### PR DESCRIPTION
Currently Universe::new() constructs a random name

This is particularly problematic for wasm environments which need to
configure `rand` with different features (`names` depends on `rand`).
A simple workaround is to allow an optional name provided to
Universe::new(). Another benefit is that the user can
associate meaningful names with universes.