### PR TITLE
Initial rust format and clippy pass to allow for using clippy and format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ itertools = "0.8"
 names = "0.11.0"
 rayon = { version = "1.0", optional = true }
 fnv = "1.0"
+derivative = "1"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+type-complexity-threshold = 500

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+fn_single_line = true

--- a/src/borrows.rs
+++ b/src/borrows.rs
@@ -84,15 +84,11 @@ impl<'a, 'b, T: 'a + Display> Display for Borrowed<'a, T> {
 }
 
 impl<'a, 'b, T: 'a + PartialEq<T>> PartialEq<Borrowed<'b, T>> for Borrowed<'a, T> {
-    fn eq(&self, other: &Borrowed<'b, T>) -> bool {
-        self.value.eq(other.value)
-    }
+    fn eq(&self, other: &Borrowed<'b, T>) -> bool { self.value.eq(other.value) }
 }
 
 impl<'a, 'b, T: 'a + PartialEq<T>> PartialEq<T> for Borrowed<'a, T> {
-    fn eq(&self, other: &T) -> bool {
-        self.value.eq(other)
-    }
+    fn eq(&self, other: &T) -> bool { self.value.eq(other) }
 }
 
 impl<'a, 'b, T: 'a + Eq> Eq for Borrowed<'a, T> {}
@@ -100,21 +96,15 @@ impl<'a, 'b, T: 'a + Eq> Eq for Borrowed<'a, T> {}
 impl<'a, T: 'a> Deref for Borrowed<'a, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for Borrowed<'a, T> {
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for Borrowed<'a, T> {
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 /// Represents a piece of mutable runtime borrow checked data.
@@ -138,27 +128,19 @@ impl<'a, T: 'a> BorrowedMut<'a, T> {
 impl<'a, T: 'a> Deref for BorrowedMut<'a, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, T: 'a> DerefMut for BorrowedMut<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for BorrowedMut<'a, T> {
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for BorrowedMut<'a, T> {
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 impl<'a, 'b, T: 'a + Debug> Debug for BorrowedMut<'a, T> {
@@ -199,9 +181,7 @@ impl<'a, T: 'a> BorrowedSlice<'a, T> {
 impl<'a, T: 'a> Deref for BorrowedSlice<'a, T> {
     type Target = [T];
 
-    fn deref(&self) -> &Self::Target {
-        self.slice
-    }
+    fn deref(&self) -> &Self::Target { self.slice }
 }
 
 impl<'a, T: 'a> IntoIterator for BorrowedSlice<'a, T> {
@@ -210,7 +190,7 @@ impl<'a, T: 'a> IntoIterator for BorrowedSlice<'a, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         BorrowedIter {
-            inner: self.slice.into_iter(),
+            inner: self.slice.iter(),
             state: self.state,
         }
     }
@@ -242,15 +222,11 @@ impl<'a, T: 'a> BorrowedMutSlice<'a, T> {
 impl<'a, T: 'a> Deref for BorrowedMutSlice<'a, T> {
     type Target = [T];
 
-    fn deref(&self) -> &Self::Target {
-        self.slice
-    }
+    fn deref(&self) -> &Self::Target { self.slice }
 }
 
 impl<'a, T: 'a> DerefMut for BorrowedMutSlice<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.slice
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { self.slice }
 }
 
 impl<'a, T: 'a> IntoIterator for BorrowedMutSlice<'a, T> {
@@ -259,7 +235,7 @@ impl<'a, T: 'a> IntoIterator for BorrowedMutSlice<'a, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         BorrowedIter {
-            inner: self.slice.into_iter(),
+            inner: self.slice.iter_mut(),
             state: self.state,
         }
     }
@@ -276,13 +252,9 @@ pub struct BorrowedIter<'a, I: 'a + Iterator> {
 impl<'a, I: 'a + Iterator> Iterator for BorrowedIter<'a, I> {
     type Item = I::Item;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
-    }
+    fn next(&mut self) -> Option<Self::Item> { self.inner.next() }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
 }
 
 impl<'a, I: 'a + ExactSizeIterator> ExactSizeIterator for BorrowedIter<'a, I> {}

--- a/src/experimental/borrow.rs
+++ b/src/experimental/borrow.rs
@@ -61,9 +61,7 @@ pub struct Borrow<'a> {
 }
 
 impl<'a> Drop for Borrow<'a> {
-    fn drop(&mut self) {
-        self.state.fetch_sub(1, Ordering::SeqCst);
-    }
+    fn drop(&mut self) { self.state.fetch_sub(1, Ordering::SeqCst); }
 }
 
 #[derive(Debug)]
@@ -72,9 +70,7 @@ pub struct BorrowMut<'a> {
 }
 
 impl<'a> Drop for BorrowMut<'a> {
-    fn drop(&mut self) {
-        self.state.store(0, Ordering::SeqCst);
-    }
+    fn drop(&mut self) { self.state.store(0, Ordering::SeqCst); }
 }
 
 #[derive(Debug)]
@@ -86,9 +82,7 @@ pub struct Ref<'a, T: 'a> {
 }
 
 impl<'a, T: 'a> Ref<'a, T> {
-    pub fn new(borrow: Borrow<'a>, value: &'a T) -> Self {
-        Self { borrow, value }
-    }
+    pub fn new(borrow: Borrow<'a>, value: &'a T) -> Self { Self { borrow, value } }
 
     pub fn map_into<K: 'a, F: FnMut(&T) -> K>(self, mut f: F) -> RefMap<'a, K> {
         RefMap {
@@ -97,29 +91,21 @@ impl<'a, T: 'a> Ref<'a, T> {
         }
     }
 
-    pub unsafe fn deconstruct(self) -> (Borrow<'a>, &'a T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (Borrow<'a>, &'a T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for Ref<'a, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for Ref<'a, T> {
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for Ref<'a, T> {
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 #[derive(Debug)]
@@ -131,9 +117,7 @@ pub struct RefMut<'a, T: 'a> {
 }
 
 impl<'a, T: 'a> RefMut<'a, T> {
-    pub fn new(borrow: BorrowMut<'a>, value: &'a mut T) -> Self {
-        Self { borrow, value }
-    }
+    pub fn new(borrow: BorrowMut<'a>, value: &'a mut T) -> Self { Self { borrow, value } }
 
     pub fn map_into<K: 'a, F: FnMut(&mut T) -> K>(mut self, mut f: F) -> RefMapMut<'a, K> {
         RefMapMut {
@@ -142,35 +126,25 @@ impl<'a, T: 'a> RefMut<'a, T> {
         }
     }
 
-    pub unsafe fn deconstruct(self) -> (BorrowMut<'a>, &'a mut T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (BorrowMut<'a>, &'a mut T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for RefMut<'a, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, T: 'a> DerefMut for RefMut<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for RefMut<'a, T> {
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMut<'a, T> {
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 #[derive(Debug)]
@@ -189,29 +163,21 @@ impl<'a, T: 'a> RefMap<'a, T> {
         }
     }
 
-    pub unsafe fn deconstruct(self) -> (Borrow<'a>, T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (Borrow<'a>, T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for RefMap<'a, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
+    fn deref(&self) -> &Self::Target { &self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for RefMap<'a, T> {
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
+    fn as_ref(&self) -> &T { &self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMap<'a, T> {
-    fn borrow(&self) -> &T {
-        &self.value
-    }
+    fn borrow(&self) -> &T { &self.value }
 }
 
 #[derive(Debug)]
@@ -230,35 +196,25 @@ impl<'a, T: 'a> RefMapMut<'a, T> {
         }
     }
 
-    pub unsafe fn deconstruct(self) -> (BorrowMut<'a>, T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (BorrowMut<'a>, T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for RefMapMut<'a, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
+    fn deref(&self) -> &Self::Target { &self.value }
 }
 
 impl<'a, T: 'a> DerefMut for RefMapMut<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for RefMapMut<'a, T> {
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
+    fn as_ref(&self) -> &T { &self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMapMut<'a, T> {
-    fn borrow(&self) -> &T {
-        &self.value
-    }
+    fn borrow(&self) -> &T { &self.value }
 }
 
 #[derive(Debug)]
@@ -285,21 +241,15 @@ impl<'a, 'b: 'a, T: 'b> ComponentRef<'a, 'b, T> {
 impl<'a, 'b: 'a, T: 'b> Deref for ComponentRef<'a, 'b, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, 'b: 'a, T: 'b> AsRef<T> for ComponentRef<'a, 'b, T> {
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, 'b: 'a, T: 'b> std::borrow::Borrow<T> for ComponentRef<'a, 'b, T> {
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 #[derive(Debug)]
@@ -326,25 +276,17 @@ impl<'a, 'b: 'a, T: 'b> ComponentRefMut<'a, 'b, T> {
 impl<'a, 'b: 'a, T: 'b> Deref for ComponentRefMut<'a, 'b, T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, 'b: 'a, T: 'b> DerefMut for ComponentRefMut<'a, 'b, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { self.value }
 }
 
 impl<'a, 'b: 'a, T: 'b> AsRef<T> for ComponentRefMut<'a, 'b, T> {
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, 'b: 'a, T: 'b> std::borrow::Borrow<T> for ComponentRefMut<'a, 'b, T> {
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }

--- a/src/experimental/filter.rs
+++ b/src/experimental/filter.rs
@@ -20,27 +20,19 @@ pub mod filter {
 
     /// Creates an entity data filter which includes chunks that contain
     /// entity data components of type `T`.
-    pub fn component<T: Component>() -> ComponentFilter<T> {
-        ComponentFilter::new()
-    }
+    pub fn component<T: Component>() -> ComponentFilter<T> { ComponentFilter::new() }
 
     /// Creates a shared data filter which includes chunks that contain
     /// shared data components of type `T`.
-    pub fn tag<T: Tag>() -> TagFilter<T> {
-        TagFilter::new()
-    }
+    pub fn tag<T: Tag>() -> TagFilter<T> { TagFilter::new() }
 
     /// Creates a shared data filter which includes chunks that contain
     /// specific shared data values.
-    pub fn tag_value<'a, T: Tag>(data: &'a T) -> TagValueFilter<'a, T> {
-        TagValueFilter::new(data)
-    }
+    pub fn tag_value<T: Tag>(data: &T) -> TagValueFilter<T> { TagValueFilter::new(data) }
 
     /// Creates a filter which includes chunks for which entity data components
     /// of type `T` have changed since the filter was last executed.
-    pub fn changed<T: Component>() -> ComponentChangedFilter<T> {
-        ComponentChangedFilter::new()
-    }
+    pub fn changed<T: Component>() -> ComponentChangedFilter<T> { ComponentChangedFilter::new() }
 }
 
 pub trait FilterResult {
@@ -67,9 +59,7 @@ impl FilterResult for Option<bool> {
     }
 
     #[inline]
-    fn is_pass(&self) -> bool {
-        self.unwrap_or(true)
-    }
+    fn is_pass(&self) -> bool { self.unwrap_or(true) }
 }
 
 pub trait Filter<'a, T> {
@@ -108,9 +98,7 @@ impl<'a> Filter<'a, ArchetypeFilterData<'a>> for Passthrough {
         std::iter::repeat(()).take(source.component_types.len())
     }
 
-    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> {
-        None
-    }
+    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> { None }
 }
 
 impl<'a> Filter<'a, ChunkFilterData<'a>> for Passthrough {
@@ -120,18 +108,14 @@ impl<'a> Filter<'a, ChunkFilterData<'a>> for Passthrough {
         std::iter::repeat(()).take(source.archetype_data.len())
     }
 
-    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> {
-        None
-    }
+    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> { None }
 }
 
 impl std::ops::Not for Passthrough {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<'a, Rhs: EntityFilter> std::ops::BitAnd<Rhs> for Passthrough {
@@ -163,9 +147,7 @@ pub struct Not<F> {
 impl<'a, T, F: Filter<'a, T>> Filter<'a, T> for Not<F> {
     type Iter = F::Iter;
 
-    fn collect(&self, source: &'a T) -> Self::Iter {
-        self.filter.collect(source)
-    }
+    fn collect(&self, source: &'a T) -> Self::Iter { self.filter.collect(source) }
 
     fn is_match(&mut self, item: <Self::Iter as Iterator>::Item) -> Option<bool> {
         self.filter.is_match(item).map(|x| !x)
@@ -335,9 +317,7 @@ impl_or_filter!(A => a, B => b, C => c, D => d, E => e, F => f);
 pub struct ComponentFilter<T>(PhantomData<T>);
 
 impl<T: Component> ComponentFilter<T> {
-    fn new() -> Self {
-        ComponentFilter(PhantomData)
-    }
+    fn new() -> Self { ComponentFilter(PhantomData) }
 }
 
 impl<'a, T: Component> Filter<'a, ArchetypeFilterData<'a>> for ComponentFilter<T> {
@@ -359,18 +339,14 @@ impl<'a, T> Filter<'a, ChunkFilterData<'a>> for ComponentFilter<T> {
         std::iter::repeat(()).take(source.archetype_data.len())
     }
 
-    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> {
-        None
-    }
+    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> { None }
 }
 
 impl<T> std::ops::Not for ComponentFilter<T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<'a, T, Rhs: EntityFilter> std::ops::BitAnd<Rhs> for ComponentFilter<T> {
@@ -398,17 +374,13 @@ impl<'a, T, Rhs: EntityFilter> std::ops::BitOr<Rhs> for ComponentFilter<T> {
 pub struct TagFilter<T>(PhantomData<T>);
 
 impl<T: Tag> TagFilter<T> {
-    fn new() -> Self {
-        TagFilter(PhantomData)
-    }
+    fn new() -> Self { TagFilter(PhantomData) }
 }
 
 impl<'a, T: Tag> Filter<'a, ArchetypeFilterData<'a>> for TagFilter<T> {
     type Iter = SliceVecIter<'a, TagTypeId>;
 
-    fn collect(&self, source: &ArchetypeFilterData<'a>) -> Self::Iter {
-        source.tag_types.iter()
-    }
+    fn collect(&self, source: &ArchetypeFilterData<'a>) -> Self::Iter { source.tag_types.iter() }
 
     fn is_match(&mut self, item: <Self::Iter as Iterator>::Item) -> Option<bool> {
         Some(item.contains(&TagTypeId::of::<T>()))
@@ -422,18 +394,14 @@ impl<'a, T> Filter<'a, ChunkFilterData<'a>> for TagFilter<T> {
         std::iter::repeat(()).take(source.archetype_data.len())
     }
 
-    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> {
-        None
-    }
+    fn is_match(&mut self, _: <Self::Iter as Iterator>::Item) -> Option<bool> { None }
 }
 
 impl<T> std::ops::Not for TagFilter<T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<'a, T, Rhs: EntityFilter> std::ops::BitAnd<Rhs> for TagFilter<T> {
@@ -463,17 +431,13 @@ pub struct TagValueFilter<'a, T> {
 }
 
 impl<'a, T: Tag> TagValueFilter<'a, T> {
-    fn new(value: &'a T) -> Self {
-        TagValueFilter { value }
-    }
+    fn new(value: &'a T) -> Self { TagValueFilter { value } }
 }
 
 impl<'a, T: Tag> Filter<'a, ArchetypeFilterData<'a>> for TagValueFilter<'a, T> {
     type Iter = SliceVecIter<'a, TagTypeId>;
 
-    fn collect(&self, source: &ArchetypeFilterData<'a>) -> Self::Iter {
-        source.tag_types.iter()
-    }
+    fn collect(&self, source: &ArchetypeFilterData<'a>) -> Self::Iter { source.tag_types.iter() }
 
     fn is_match(&mut self, item: <Self::Iter as Iterator>::Item) -> Option<bool> {
         Some(item.contains(&TagTypeId::of::<T>()))
@@ -487,7 +451,7 @@ impl<'a, T: Tag> Filter<'a, ChunkFilterData<'a>> for TagValueFilter<'a, T> {
         unsafe {
             source
                 .archetype_data
-                .tags(&TagTypeId::of::<T>())
+                .tags(TagTypeId::of::<T>())
                 .unwrap()
                 .data_slice::<T>()
                 .iter()
@@ -503,9 +467,7 @@ impl<'a, T> std::ops::Not for TagValueFilter<'a, T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<'a, T, Rhs: EntityFilter> std::ops::BitAnd<Rhs> for TagValueFilter<'a, T> {
@@ -565,7 +527,7 @@ impl<'a, T: Component> Filter<'a, ChunkFilterData<'a>> for ComponentChangedFilte
 
     fn is_match(&mut self, item: <Self::Iter as Iterator>::Item) -> Option<bool> {
         use std::collections::hash_map::Entry;
-        let components = item.components(&ComponentTypeId::of::<T>()).unwrap();
+        let components = item.components(ComponentTypeId::of::<T>()).unwrap();
         let version = components.version();
         match self.versions.entry(item.id()) {
             Entry::Occupied(mut entry) => Some(entry.insert(version) != version),
@@ -581,9 +543,7 @@ impl<'a, T: Component> std::ops::Not for ComponentChangedFilter<T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<'a, T: Component, Rhs: EntityFilter> std::ops::BitAnd<Rhs> for ComponentChangedFilter<T> {

--- a/src/experimental/lib.rs
+++ b/src/experimental/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod borrow;
 pub mod entity;
 pub mod filter;

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub mod borrow;
 pub mod entity;
 pub mod filter;

--- a/src/experimental/storage.rs
+++ b/src/experimental/storage.rs
@@ -1,5 +1,6 @@
 use crate::experimental::borrow::{AtomicRefCell, Ref, RefMap, RefMapMut, RefMut};
 use crate::experimental::entity::Entity;
+use derivative::Derivative;
 use std::any::TypeId;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
@@ -14,18 +15,14 @@ use std::sync::Arc;
 pub struct ComponentTypeId(TypeId);
 
 impl ComponentTypeId {
-    pub fn of<T: Component>() -> Self {
-        ComponentTypeId(TypeId::of::<T>())
-    }
+    pub fn of<T: Component>() -> Self { ComponentTypeId(TypeId::of::<T>()) }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TagTypeId(TypeId);
 
 impl TagTypeId {
-    pub fn of<T: Tag>() -> Self {
-        TagTypeId(TypeId::of::<T>())
-    }
+    pub fn of<T: Tag>() -> Self { TagTypeId(TypeId::of::<T>()) }
 }
 
 pub trait Component: Copy + 'static {}
@@ -34,45 +31,41 @@ pub trait Tag: Copy + PartialEq + 'static {}
 impl<T: Copy + 'static> Component for T {}
 impl<T: Copy + PartialEq + 'static> Tag for T {}
 
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct ComponentTypes(SliceVec<ComponentTypeId>);
+
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct TagTypes(SliceVec<TagTypeId>);
 
 impl ComponentTypes {
-    pub fn iter(&self) -> SliceVecIter<ComponentTypeId> {
-        self.0.iter()
-    }
+    pub fn iter(&self) -> SliceVecIter<ComponentTypeId> { self.0.iter() }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
+    pub fn len(&self) -> usize { self.0.len() }
+
+    pub fn is_empty(&self) -> bool { self.len() < 1 }
 }
 
 impl TagTypes {
-    pub fn iter(&self) -> SliceVecIter<TagTypeId> {
-        self.0.iter()
-    }
+    pub fn iter(&self) -> SliceVecIter<TagTypeId> { self.0.iter() }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
+    pub fn len(&self) -> usize { self.0.len() }
+
+    pub fn is_empty(&self) -> bool { self.len() < 1 }
 }
 
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct SliceVec<T> {
     data: Vec<T>,
     counts: Vec<usize>,
 }
 
 impl<T> SliceVec<T> {
-    pub fn new() -> Self {
-        Self {
-            data: Vec::new(),
-            counts: Vec::new(),
-        }
-    }
+    pub fn len(&self) -> usize { self.counts.len() }
 
-    pub fn len(&self) -> usize {
-        self.counts.len()
-    }
+    pub fn is_empty(&self) -> bool { self.len() < 1 }
 
     pub fn push<I: IntoIterator<Item = T>>(&mut self, items: I) {
         let mut count = 0;
@@ -111,6 +104,7 @@ impl<'a, T> Iterator for SliceVecIter<'a, T> {
     }
 }
 
+#[derive(Default)]
 pub struct Storage {
     component_types: ComponentTypes,
     tag_types: TagTypes,
@@ -118,14 +112,6 @@ pub struct Storage {
 }
 
 impl Storage {
-    pub fn new() -> Self {
-        Storage {
-            component_types: ComponentTypes(SliceVec::new()),
-            tag_types: TagTypes(SliceVec::new()),
-            chunks: Vec::new(),
-        }
-    }
-
     pub fn alloc_archetype(
         &mut self,
         desc: &ArchetypeDescription,
@@ -148,21 +134,15 @@ impl Storage {
         })
     }
 
-    pub fn component_types(&self) -> &ComponentTypes {
-        &self.component_types
-    }
+    pub fn component_types(&self) -> &ComponentTypes { &self.component_types }
 
-    pub fn tag_types(&self) -> &TagTypes {
-        &self.tag_types
-    }
+    pub fn tag_types(&self) -> &TagTypes { &self.tag_types }
 
     pub fn iter_component_types(&self) -> SliceVecIter<ComponentTypeId> {
         self.component_types.0.iter()
     }
 
-    pub fn iter_tag_types(&self) -> SliceVecIter<TagTypeId> {
-        self.tag_types.0.iter()
-    }
+    pub fn iter_tag_types(&self) -> SliceVecIter<TagTypeId> { self.tag_types.0.iter() }
 
     pub fn data(&self, archetype: usize) -> Option<&Arc<AtomicRefCell<ArchetypeData>>> {
         self.chunks.get(archetype)
@@ -188,19 +168,13 @@ pub struct ComponentMeta {
     drop_fn: Option<(fn(*mut u8))>,
 }
 
+#[derive(Default)]
 pub struct ArchetypeDescription {
     tags: Vec<(TagTypeId, TagMeta)>,
     components: Vec<(ComponentTypeId, ComponentMeta)>,
 }
 
 impl ArchetypeDescription {
-    pub fn new() -> Self {
-        ArchetypeDescription {
-            tags: Vec::new(),
-            components: Vec::new(),
-        }
-    }
-
     pub fn register_tag_raw(&mut self, type_id: TagTypeId, type_meta: TagMeta) {
         self.tags.push((type_id, type_meta));
     }
@@ -284,7 +258,7 @@ impl ArchetypeData {
 
         ArchetypeData {
             id,
-            tags: tags,
+            tags,
             component_layout: ComponentStorageLayout {
                 capacity: entity_capacity,
                 alloc_layout: data_alignment,
@@ -312,13 +286,11 @@ impl ArchetypeData {
         )
     }
 
-    pub fn len(&self) -> usize {
-        self.component_chunks.len()
-    }
+    pub fn len(&self) -> usize { self.component_chunks.len() }
 
-    pub fn tags(&self, tag_type: &TagTypeId) -> Option<&TagStorage> {
-        self.tags.get(tag_type)
-    }
+    pub fn is_empty(&self) -> bool { self.len() < 1 }
+
+    pub fn tags(&self, tag_type: TagTypeId) -> Option<&TagStorage> { self.tags.get(&tag_type) }
 
     pub fn iter_component_chunks(&self) -> std::slice::Iter<ComponentStorage> {
         self.component_chunks.iter()
@@ -333,9 +305,7 @@ impl ArchetypeData {
     }
 }
 
-fn align_up(addr: usize, align: usize) -> usize {
-    (addr + (align - 1)) & align.wrapping_neg()
-}
+fn align_up(addr: usize, align: usize) -> usize { (addr + (align - 1)) & align.wrapping_neg() }
 
 pub struct ComponentStorageLayout {
     capacity: usize,
@@ -355,12 +325,12 @@ impl ComponentStorageLayout {
                         *ty,
                         ComponentAccessor {
                             ptr: AtomicRefCell::new(NonNull::new_unchecked(
-                                data_storage.offset(*offset as isize),
+                                data_storage.add(*offset),
                             )),
                             capacity: self.capacity,
                             count: UnsafeCell::new(0),
                             element_size: meta.size,
-                            drop_fn: meta.drop_fn.clone(),
+                            drop_fn: meta.drop_fn,
                             version: UnsafeCell::new(Wrapping(0)),
                         },
                     )
@@ -392,28 +362,20 @@ pub struct ComponentStorage {
 }
 
 impl ComponentStorage {
-    pub fn id(&self) -> ChunkId {
-        self.id
-    }
+    pub fn id(&self) -> ChunkId { self.id }
 
-    pub fn len(&self) -> usize {
-        self.entities.len()
-    }
+    pub fn len(&self) -> usize { self.entities.len() }
 
-    pub fn capacity(&self) -> usize {
-        self.capacity
-    }
+    pub fn capacity(&self) -> usize { self.capacity }
 
-    pub fn is_full(&self) -> bool {
-        self.len() >= self.capacity
-    }
+    pub fn is_full(&self) -> bool { self.len() >= self.capacity }
 
-    pub fn entities(&self) -> &[Entity] {
-        self.entities.as_slice()
-    }
+    pub fn is_empty(&self) -> bool { self.entities.len() < 1 }
 
-    pub fn components(&self, component_type: &ComponentTypeId) -> Option<&ComponentAccessor> {
-        unsafe { &*self.component_info.get() }.get(component_type)
+    pub fn entities(&self) -> &[Entity] { self.entities.as_slice() }
+
+    pub fn components(&self, component_type: ComponentTypeId) -> Option<&ComponentAccessor> {
+        unsafe { &*self.component_info.get() }.get(&component_type)
     }
 
     pub fn swap_remove(&mut self, index: usize) -> Option<Entity> {
@@ -464,9 +426,7 @@ pub struct ComponentAccessor {
 }
 
 impl ComponentAccessor {
-    pub fn version(&self) -> usize {
-        unsafe { (*self.version.get()).0 }
-    }
+    pub fn version(&self) -> usize { unsafe { (*self.version.get()).0 } }
 
     pub unsafe fn data_raw<'a>(&'a self) -> (Ref<'a, NonNull<u8>>, usize, usize) {
         (
@@ -499,9 +459,7 @@ impl ComponentAccessor {
         ptr.map_into(|ptr| std::slice::from_raw_parts_mut(ptr.as_ptr() as *mut T, count))
     }
 
-    pub unsafe fn writer(&mut self) -> ComponentWriter {
-        ComponentWriter::new(self)
-    }
+    pub unsafe fn writer(&mut self) -> ComponentWriter { ComponentWriter::new(self) }
 }
 
 impl Debug for ComponentAccessor {
@@ -536,7 +494,7 @@ impl<'a> ComponentWriter<'a> {
             components.as_ptr(),
             self.ptr
                 .as_ptr()
-                .offset((*self.accessor.count.get() * self.accessor.element_size) as isize),
+                .add(*self.accessor.count.get() * self.accessor.element_size),
             count * self.accessor.element_size,
         );
         *self.accessor.count.get() += count;
@@ -554,12 +512,12 @@ impl<'a> ComponentWriter<'a> {
         unsafe {
             let size = self.accessor.element_size;
             let count = *self.accessor.count.get();
-            let to_remove = self.ptr.as_ptr().offset((size * index) as isize);
+            let to_remove = self.ptr.as_ptr().add(size * index);
             if let Some(drop_fn) = self.accessor.drop_fn {
                 drop_fn(to_remove);
             }
             if index < count - 1 {
-                let swap_target = self.ptr.as_ptr().offset((size * (count - 1)) as isize);
+                let swap_target = self.ptr.as_ptr().add(size * (count - 1));
                 std::ptr::copy_nonoverlapping(swap_target, to_remove, size);
             }
 
@@ -598,23 +556,18 @@ impl TagStorage {
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.len
-    }
+    pub fn len(&self) -> usize { self.len }
 
-    pub fn push_raw(&mut self, ptr: *const u8) {
+    pub fn is_empty(&self) -> bool { self.len() < 1 }
+
+    pub unsafe fn push_raw(&mut self, ptr: *const u8) {
         if self.len == self.capacity {
             self.grow();
         }
 
         if self.element.size > 0 {
-            unsafe {
-                let dst = self
-                    .ptr
-                    .as_ptr()
-                    .offset((self.len * self.element.size) as isize);
-                std::ptr::copy_nonoverlapping(ptr, dst, self.element.size);
-            }
+            let dst = self.ptr.as_ptr().add(self.len * self.element.size);
+            std::ptr::copy_nonoverlapping(ptr, dst, self.element.size);
         }
 
         self.len += 1;
@@ -625,8 +578,11 @@ impl TagStorage {
             size_of::<T>() == self.element.size,
             "incompatible element data size"
         );
-        self.push_raw(&value as *const T as *const u8);
-        std::mem::forget(value);
+        unsafe {
+            self.push_raw(&value as *const T as *const u8);
+        }
+        // This doens't need to happen because the type is copy.
+        //std::mem::forget(value);
     }
 
     pub unsafe fn data_raw(&self) -> (NonNull<u8>, usize, usize) {
@@ -657,7 +613,7 @@ impl TagStorage {
                 (new_cap, ptr)
             };
 
-            if ptr == std::ptr::null_mut() {
+            if ptr.is_null() {
                 println!("out of memory");
                 std::process::abort()
             }
@@ -676,7 +632,7 @@ impl Drop for TagStorage {
             unsafe {
                 if let Some(drop_fn) = self.element.drop_fn {
                     for i in 0..self.len {
-                        drop_fn(ptr.offset((i * self.element.size) as isize));
+                        drop_fn(ptr.add(i * self.element.size));
                     }
                 }
                 let layout = std::alloc::Layout::from_size_align_unchecked(
@@ -708,9 +664,9 @@ mod test {
 
     #[test]
     pub fn create() {
-        let mut archetypes = Storage::new();
+        let mut archetypes = Storage::default();
 
-        let mut desc = ArchetypeDescription::new();
+        let mut desc = ArchetypeDescription::default();
         desc.register_tag::<usize>();
         desc.register_component::<isize>();
 
@@ -735,9 +691,9 @@ mod test {
 
     #[test]
     pub fn read_components() {
-        let mut archetypes = Storage::new();
+        let mut archetypes = Storage::default();
 
-        let mut desc = ArchetypeDescription::new();
+        let mut desc = ArchetypeDescription::default();
         desc.register_component::<isize>();
         desc.register_component::<usize>();
         desc.register_component::<ZeroSize>();
@@ -808,9 +764,9 @@ mod test {
 
     #[test]
     pub fn read_tags() {
-        let mut archetypes = Storage::new();
+        let mut archetypes = Storage::default();
 
-        let mut desc = ArchetypeDescription::new();
+        let mut desc = ArchetypeDescription::default();
         desc.register_tag::<isize>();
         desc.register_tag::<ZeroSize>();
 
@@ -828,7 +784,7 @@ mod test {
 
         unsafe {
             let tags1 = data
-                .tags(&TagTypeId::of::<isize>())
+                .tags(TagTypeId::of::<isize>())
                 .unwrap()
                 .data_slice::<isize>();
             assert_eq!(tags1.len(), tag_values.len());
@@ -837,7 +793,7 @@ mod test {
             }
 
             let tags2 = data
-                .tags(&TagTypeId::of::<ZeroSize>())
+                .tags(TagTypeId::of::<ZeroSize>())
                 .unwrap()
                 .data_slice::<ZeroSize>();
             assert_eq!(tags2.len(), tag_values.len());
@@ -849,9 +805,9 @@ mod test {
 
     #[test]
     pub fn create_zero_size_tags() {
-        let mut archetypes = Storage::new();
+        let mut archetypes = Storage::default();
 
-        let mut desc = ArchetypeDescription::new();
+        let mut desc = ArchetypeDescription::default();
         desc.register_tag::<ZeroSize>();
         desc.register_component::<isize>();
 
@@ -876,9 +832,9 @@ mod test {
 
     #[test]
     pub fn create_zero_size_components() {
-        let mut archetypes = Storage::new();
+        let mut archetypes = Storage::default();
 
-        let mut desc = ArchetypeDescription::new();
+        let mut desc = ArchetypeDescription::default();
         desc.register_tag::<usize>();
         desc.register_component::<ZeroSize>();
 

--- a/src/experimental/world.rs
+++ b/src/experimental/world.rs
@@ -29,14 +29,15 @@ pub struct Universe {
 }
 
 impl Universe {
-    pub fn new() -> Self {
-        Universe {
-            allocator: Arc::from(Mutex::new(BlockAllocator::new())),
-        }
-    }
+    pub fn new() -> Self { Self::default() }
+    pub fn create_world(&self) -> World { World::new(EntityAllocator::new(self.allocator.clone())) }
+}
 
-    pub fn create_world(&self) -> World {
-        World::new(EntityAllocator::new(self.allocator.clone()))
+impl Default for Universe {
+    fn default() -> Self {
+        Self {
+            allocator: Arc::new(Mutex::new(BlockAllocator::new())),
+        }
     }
 }
 
@@ -48,7 +49,7 @@ pub struct World {
 impl World {
     pub fn new(allocator: EntityAllocator) -> Self {
         Self {
-            archetypes: Storage::new(),
+            archetypes: Storage::default(),
             entity_allocator: allocator,
         }
     }
@@ -79,18 +80,18 @@ impl World {
             let added = component_storage.entities().iter().enumerate().skip(start);
             for (i, e) in added {
                 let location = EntityLocation::new(archetype_id, chunk_id, i);
-                self.entity_allocator.set_location(&e.index(), location);
+                self.entity_allocator.set_location(e.index(), location);
             }
         }
 
         self.entity_allocator.allocation_buffer()
     }
 
-    pub fn delete(&mut self, entity: &Entity) -> bool {
-        let deleted = self.entity_allocator.delete_entity(*entity);
+    pub fn delete(&mut self, entity: Entity) -> bool {
+        let deleted = self.entity_allocator.delete_entity(entity);
 
         if deleted {
-            let location = *self.entity_allocator.get_location(&entity.index()).unwrap();
+            let location = self.entity_allocator.get_location(entity.index()).unwrap();
             let mut archetype = self
                 .archetypes
                 .data(location.archetype())
@@ -100,23 +101,21 @@ impl World {
             let chunk = archetype.component_chunk_mut(location.chunk()).unwrap();
             if let Some(swapped) = chunk.swap_remove(location.component()) {
                 self.entity_allocator
-                    .set_location(&swapped.index(), location);
+                    .set_location(swapped.index(), location);
             }
         }
 
         deleted
     }
 
-    pub fn is_alive(&self, entity: &Entity) -> bool {
-        self.entity_allocator.is_alive(entity)
-    }
+    pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
 
-    pub fn get_component<T: Component>(&mut self, entity: &Entity) -> Option<ComponentRef<T>> {
+    pub fn get_component<T: Component>(&mut self, entity: Entity) -> Option<ComponentRef<T>> {
         if !self.is_alive(entity) {
             return None;
         }
 
-        let location = self.entity_allocator.get_location(&entity.index())?;
+        let location = self.entity_allocator.get_location(entity.index())?;
         let (archetype_borrow, archetype) = unsafe {
             self.archetypes
                 .data(location.archetype())?
@@ -127,7 +126,7 @@ impl World {
         let chunk = archetype.component_chunk(location.chunk())?;
         let (slice_borrow, slice) = unsafe {
             chunk
-                .components(&ComponentTypeId::of::<T>())?
+                .components(ComponentTypeId::of::<T>())?
                 .data_slice::<T>()
                 .deconstruct()
         };
@@ -138,13 +137,13 @@ impl World {
 
     pub fn get_component_mut<T: Component>(
         &mut self,
-        entity: &Entity,
+        entity: Entity,
     ) -> Option<ComponentRefMut<T>> {
         if !self.is_alive(entity) {
             return None;
         }
 
-        let location = self.entity_allocator.get_location(&entity.index())?;
+        let location = self.entity_allocator.get_location(entity.index())?;
         let (archetype_borrow, archetype) = unsafe {
             self.archetypes
                 .data(location.archetype())?
@@ -155,7 +154,7 @@ impl World {
         let chunk = archetype.component_chunk(location.chunk())?;
         let (slice_borrow, slice) = unsafe {
             chunk
-                .components(&ComponentTypeId::of::<T>())?
+                .components(ComponentTypeId::of::<T>())?
                 .data_slice_mut::<T>()
                 .deconstruct()
         };
@@ -168,12 +167,12 @@ impl World {
         ))
     }
 
-    pub fn get_tag<T: Tag>(&self, entity: &Entity) -> Option<Ref<T>> {
+    pub fn get_tag<T: Tag>(&self, entity: Entity) -> Option<Ref<T>> {
         if !self.is_alive(entity) {
             return None;
         }
 
-        let location = self.entity_allocator.get_location(&entity.index())?;
+        let location = self.entity_allocator.get_location(entity.index())?;
         let (archetype_borrow, archetype) = unsafe {
             self.archetypes
                 .data(location.archetype())?
@@ -181,7 +180,7 @@ impl World {
                 .expect("archetype currently mutably borrowed elsewhere")
                 .deconstruct()
         };
-        let tags = archetype.tags(&TagTypeId::of::<T>())?;
+        let tags = archetype.tags(TagTypeId::of::<T>())?;
         let tag = unsafe { tags.data_slice::<T>().get(location.chunk())? };
 
         Some(Ref::new(archetype_borrow, tag))
@@ -214,7 +213,7 @@ impl World {
             };
         }
 
-        let mut description = ArchetypeDescription::new();
+        let mut description = ArchetypeDescription::default();
         tags.tailor_archetype(&mut description);
         components.tailor_archetype(&mut description);
 
@@ -455,7 +454,7 @@ mod tuple_impls {
                         $(
                             unsafe {
                                 source.archetype_data
-                                    .tags(&TagTypeId::of::<$ty>())
+                                    .tags(TagTypeId::of::<$ty>())
                                     .unwrap()
                                     .data_slice::<$ty>()
                                     .iter()
@@ -499,8 +498,6 @@ mod tuple_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parking_lot::Mutex;
-    use std::sync::Arc;
 
     #[derive(Clone, Copy, Debug, PartialEq)]
     struct Pos(f32, f32, f32);
@@ -523,9 +520,7 @@ mod tests {
     }
 
     #[test]
-    fn create_universe() {
-        Universe::new();
-    }
+    fn create_universe() { Universe::default(); }
 
     #[test]
     fn create_world() {
@@ -563,11 +558,11 @@ mod tests {
             .iter()
             .enumerate()
         {
-            match world.get_component(&e) {
+            match world.get_component(*e) {
                 Some(x) => assert_eq!(components.get(i).map(|(x, _)| x), Some(&x as &Pos)),
                 None => assert_eq!(components.get(i).map(|(x, _)| x), None),
             }
-            match world.get_component(&e) {
+            match world.get_component(*e) {
                 Some(x) => assert_eq!(components.get(i).map(|(_, x)| x), Some(&x as &Rot)),
                 None => assert_eq!(components.get(i).map(|(_, x)| x), None),
             }
@@ -582,7 +577,7 @@ mod tests {
 
         let entity = *world.entity_allocator.allocation_buffer().get(0).unwrap();
 
-        assert!(world.get_component::<i32>(&entity).is_none());
+        assert!(world.get_component::<i32>(entity).is_none());
     }
 
     #[test]
@@ -598,8 +593,8 @@ mod tests {
         world.insert(shared, components);
 
         for e in world.entity_allocator.allocation_buffer().iter() {
-            assert_eq!(&Static, world.get_tag::<Static>(&e).unwrap().deref());
-            assert_eq!(&Model(5), world.get_tag::<Model>(&e).unwrap().deref());
+            assert_eq!(&Static, world.get_tag::<Static>(*e).unwrap().deref());
+            assert_eq!(&Model(5), world.get_tag::<Model>(*e).unwrap().deref());
         }
     }
 
@@ -611,7 +606,7 @@ mod tests {
 
         let entity = world.entity_allocator.allocation_buffer().get(0).unwrap();
 
-        assert!(world.get_tag::<Model>(entity).is_none());
+        assert!(world.get_tag::<Model>(*entity).is_none());
     }
 
     #[test]
@@ -627,12 +622,12 @@ mod tests {
         let entities = world.insert(shared, components).to_vec();
 
         for e in entities.iter() {
-            assert!(world.get_component::<Pos>(e).is_some());
+            assert!(world.get_component::<Pos>(*e).is_some());
         }
 
         for e in entities.iter() {
-            world.delete(e);
-            assert!(world.get_component::<Pos>(e).is_none());
+            world.delete(*e);
+            assert!(world.get_component::<Pos>(*e).is_none());
         }
     }
 
@@ -649,14 +644,14 @@ mod tests {
         let entities = world.insert(shared, components.clone()).to_vec();
 
         let last = *entities.last().unwrap();
-        world.delete(&last);
+        world.delete(last);
 
         for (i, e) in entities.iter().take(entities.len() - 1).enumerate() {
-            match world.get_component(&e) {
+            match world.get_component(*e) {
                 Some(x) => assert_eq!(components.get(i).map(|(x, _)| x), Some(&x as &Pos)),
                 None => assert_eq!(components.get(i).map(|(x, _)| x), None),
             }
-            match world.get_component(&e) {
+            match world.get_component(*e) {
                 Some(x) => assert_eq!(components.get(i).map(|(_, x)| x), Some(&x as &Rot)),
                 None => assert_eq!(components.get(i).map(|(_, x)| x), None),
             }
@@ -676,14 +671,14 @@ mod tests {
         let entities = world.insert(shared, components.clone()).to_vec();
 
         let first = *entities.first().unwrap();
-        world.delete(&first);
+        world.delete(first);
 
         for (i, e) in entities.iter().skip(1).enumerate() {
-            match world.get_component(&e) {
+            match world.get_component(*e) {
                 Some(x) => assert_eq!(components.get(i + 1).map(|(x, _)| x), Some(&x as &Pos)),
                 None => assert_eq!(components.get(i + 1).map(|(x, _)| x), None),
             }
-            match world.get_component(&e) {
+            match world.get_component(*e) {
                 Some(x) => assert_eq!(components.get(i + 1).map(|(_, x)| x), Some(&x as &Rot)),
                 None => assert_eq!(components.get(i + 1).map(|(_, x)| x), None),
             }

--- a/src/query.rs
+++ b/src/query.rs
@@ -70,29 +70,19 @@ pub struct Read<T: Component>(PhantomData<T>);
 impl<T: Component> DefaultFilter for Read<T> {
     type Filter = ComponentFilter<T>;
 
-    fn filter() -> Self::Filter {
-        ComponentFilter::new()
-    }
+    fn filter() -> Self::Filter { ComponentFilter::new() }
 }
 
 impl<'a, T: Component> View<'a> for Read<T> {
     type Iter = BorrowedIter<'a, Iter<'a, T>>;
 
-    fn fetch(chunk: &'a Chunk) -> Self::Iter {
-        chunk.components().unwrap().into_iter()
-    }
+    fn fetch(chunk: &'a Chunk) -> Self::Iter { chunk.components().unwrap().into_iter() }
 
-    fn validate() -> bool {
-        true
-    }
+    fn validate() -> bool { true }
 
-    fn reads<D: Component>() -> bool {
-        TypeId::of::<T>() == TypeId::of::<D>()
-    }
+    fn reads<D: Component>() -> bool { TypeId::of::<T>() == TypeId::of::<D>() }
 
-    fn writes<D: Component>() -> bool {
-        false
-    }
+    fn writes<D: Component>() -> bool { false }
 }
 
 impl<T: Component> ViewElement for Read<T> {
@@ -105,29 +95,19 @@ pub struct Write<T: Component>(PhantomData<T>);
 
 impl<T: Component> DefaultFilter for Write<T> {
     type Filter = ComponentFilter<T>;
-    fn filter() -> Self::Filter {
-        ComponentFilter::new()
-    }
+    fn filter() -> Self::Filter { ComponentFilter::new() }
 }
 
 impl<'a, T: Component> View<'a> for Write<T> {
     type Iter = BorrowedIter<'a, IterMut<'a, T>>;
 
-    fn fetch(chunk: &'a Chunk) -> Self::Iter {
-        chunk.components_mut().unwrap().into_iter()
-    }
+    fn fetch(chunk: &'a Chunk) -> Self::Iter { chunk.components_mut().unwrap().into_iter() }
 
-    fn validate() -> bool {
-        true
-    }
+    fn validate() -> bool { true }
 
-    fn reads<D: Component>() -> bool {
-        TypeId::of::<T>() == TypeId::of::<D>()
-    }
+    fn reads<D: Component>() -> bool { TypeId::of::<T>() == TypeId::of::<D>() }
 
-    fn writes<D: Component>() -> bool {
-        TypeId::of::<T>() == TypeId::of::<D>()
-    }
+    fn writes<D: Component>() -> bool { TypeId::of::<T>() == TypeId::of::<D>() }
 }
 
 impl<T: Component> ViewElement for Write<T> {
@@ -140,9 +120,7 @@ pub struct Tagged<T: Tag>(PhantomData<T>);
 
 impl<T: Tag> DefaultFilter for Tagged<T> {
     type Filter = TagFilter<T>;
-    fn filter() -> Self::Filter {
-        TagFilter::new()
-    }
+    fn filter() -> Self::Filter { TagFilter::new() }
 }
 
 impl<'a, T: Tag> View<'a> for Tagged<T> {
@@ -153,17 +131,11 @@ impl<'a, T: Tag> View<'a> for Tagged<T> {
         std::iter::repeat(data).take(chunk.len())
     }
 
-    fn validate() -> bool {
-        true
-    }
+    fn validate() -> bool { true }
 
-    fn reads<D: Component>() -> bool {
-        false
-    }
+    fn reads<D: Component>() -> bool { false }
 
-    fn writes<D: Component>() -> bool {
-        false
-    }
+    fn writes<D: Component>() -> bool { false }
 }
 
 impl<T: Tag> ViewElement for Tagged<T> {
@@ -243,17 +215,13 @@ impl FilterResult for Option<bool> {
     }
 
     #[inline]
-    fn is_pass(&self) -> bool {
-        self.unwrap_or(true)
-    }
+    fn is_pass(&self) -> bool { self.unwrap_or(true) }
 }
 
 /// Filters chunks to determine which are to be included in a `Query`.
 pub trait Filter: Send + Sync + Sized + Debug {
     /// Determines if an archetype matches the filter's conditions.
-    fn filter_archetype(&self, _: &Archetype) -> Option<bool> {
-        None
-    }
+    fn filter_archetype(&self, _: &Archetype) -> Option<bool> { None }
 
     /// Determines if a chunk matches immutable elements of the filter's conditions.
     /// This must always return the same result when given the same chunk.
@@ -276,27 +244,19 @@ pub mod filter {
 
     /// Creates an entity data filter which includes chunks that contain
     /// entity data components of type `T`.
-    pub fn component<T: Component>() -> ComponentFilter<T> {
-        ComponentFilter::new()
-    }
+    pub fn component<T: Component>() -> ComponentFilter<T> { ComponentFilter::new() }
 
     /// Creates a shared data filter which includes chunks that contain
     /// shared data components of type `T`.
-    pub fn tag<T: Tag>() -> TagFilter<T> {
-        TagFilter::new()
-    }
+    pub fn tag<T: Tag>() -> TagFilter<T> { TagFilter::new() }
 
     /// Creates a shared data filter which includes chunks that contain
     /// specific shared data values.
-    pub fn tag_value<'a, T: Tag>(data: &'a T) -> TagValueFilter<'a, T> {
-        TagValueFilter::new(data)
-    }
+    pub fn tag_value<T: Tag>(data: &T) -> TagValueFilter<'_, T> { TagValueFilter::new(data) }
 
     /// Creates a filter which includes chunks for which entity data components
     /// of type `T` have changed since the filter was last executed.
-    pub fn changed<T: Component>() -> ComponentChangedFilter<T> {
-        ComponentChangedFilter::new()
-    }
+    pub fn changed<T: Component>() -> ComponentChangedFilter<T> { ComponentChangedFilter::new() }
 }
 
 /// A passthrough filter which allows all chunks.
@@ -305,23 +265,17 @@ pub struct Passthrough;
 
 impl Filter for Passthrough {
     #[inline]
-    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> { None }
 
     #[inline]
-    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> { None }
 }
 
 impl std::ops::Not for Passthrough {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<Rhs: Filter> std::ops::BitAnd<Rhs> for Passthrough {
@@ -373,9 +327,7 @@ impl<T: Filter> std::ops::Not for Not<T> {
     type Output = T;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        self.filter
-    }
+    fn not(self) -> Self::Output { self.filter }
 }
 
 impl<F: Filter, Rhs: Filter> std::ops::BitAnd<Rhs> for Not<F> {
@@ -563,9 +515,7 @@ impl_or_filter!(A, B, C, D, E, F);
 pub struct ComponentFilter<T>(PhantomData<T>);
 
 impl<T: Component> ComponentFilter<T> {
-    fn new() -> Self {
-        ComponentFilter(PhantomData)
-    }
+    fn new() -> Self { ComponentFilter(PhantomData) }
 }
 
 impl<T: Component> Filter for ComponentFilter<T> {
@@ -575,23 +525,17 @@ impl<T: Component> Filter for ComponentFilter<T> {
     }
 
     #[inline]
-    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> { None }
 
     #[inline]
-    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> { None }
 }
 
 impl<T: Component> std::ops::Not for ComponentFilter<T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<Rhs: Filter, T: Component> std::ops::BitAnd<Rhs> for ComponentFilter<T> {
@@ -621,9 +565,7 @@ impl<Rhs: Filter, T: Component> std::ops::BitOr<Rhs> for ComponentFilter<T> {
 pub struct TagFilter<T>(PhantomData<T>);
 
 impl<T: Tag> TagFilter<T> {
-    fn new() -> Self {
-        TagFilter(PhantomData)
-    }
+    fn new() -> Self { TagFilter(PhantomData) }
 }
 
 impl<T: Tag> Filter for TagFilter<T> {
@@ -633,23 +575,17 @@ impl<T: Tag> Filter for TagFilter<T> {
     }
 
     #[inline]
-    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> { None }
 
     #[inline]
-    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> { None }
 }
 
 impl<T: Tag> std::ops::Not for TagFilter<T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<Rhs: Filter, T: Tag> std::ops::BitAnd<Rhs> for TagFilter<T> {
@@ -681,9 +617,7 @@ pub struct TagValueFilter<'a, T> {
 }
 
 impl<'a, T: Tag> TagValueFilter<'a, T> {
-    fn new(value: &'a T) -> Self {
-        TagValueFilter { value }
-    }
+    fn new(value: &'a T) -> Self { TagValueFilter { value } }
 }
 
 impl<'a, T: Tag> Filter for TagValueFilter<'a, T> {
@@ -698,18 +632,14 @@ impl<'a, T: Tag> Filter for TagValueFilter<'a, T> {
     }
 
     #[inline]
-    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_variable(&mut self, _: &Chunk) -> Option<bool> { None }
 }
 
 impl<'a, T: Tag> std::ops::Not for TagValueFilter<'a, T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<'a, Rhs: Filter, T: Tag> std::ops::BitAnd<Rhs> for TagValueFilter<'a, T> {
@@ -755,9 +685,7 @@ impl<T: Component> std::ops::Not for ComponentChangedFilter<T> {
     type Output = Not<Self>;
 
     #[inline]
-    fn not(self) -> Self::Output {
-        Not { filter: self }
-    }
+    fn not(self) -> Self::Output { Not { filter: self } }
 }
 
 impl<T: Component> Filter for ComponentChangedFilter<T> {
@@ -767,9 +695,7 @@ impl<T: Component> Filter for ComponentChangedFilter<T> {
     }
 
     #[inline]
-    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> {
-        None
-    }
+    fn filter_chunk_immutable(&self, _: &Chunk) -> Option<bool> { None }
 
     fn filter_chunk_variable(&mut self, chunk: &Chunk) -> Option<bool> {
         use std::collections::hash_map::Entry;
@@ -1202,15 +1128,11 @@ pub struct ChunkView<'a, V: View<'a>> {
 impl<'a, V: View<'a>> ChunkView<'a, V> {
     /// Get a slice of all entities contained within the chunk.
     #[inline]
-    pub fn entities(&self) -> &'a [Entity] {
-        unsafe { self.chunk.entities() }
-    }
+    pub fn entities(&self) -> &'a [Entity] { unsafe { self.chunk.entities() } }
 
     /// Get an iterator of all data contained within the chunk.
     #[inline]
-    pub fn iter(&mut self) -> V::Iter {
-        V::fetch(self.chunk)
-    }
+    pub fn iter(&mut self) -> V::Iter { V::fetch(self.chunk) }
 
     /// Get an iterator of all data and entity IDs contained within the chunk.
     #[inline]
@@ -1224,9 +1146,7 @@ impl<'a, V: View<'a>> ChunkView<'a, V> {
     }
 
     /// Get a tag value.
-    pub fn tag<T: Tag>(&self) -> Option<&T> {
-        self.chunk.tag()
-    }
+    pub fn tag<T: Tag>(&self) -> Option<&T> { self.chunk.tag() }
 
     /// Get a slice of component data.
     ///

--- a/tests/query_api.rs
+++ b/tests/query_api.rs
@@ -1,7 +1,9 @@
 use legion::prelude::*;
 use rayon::prelude::*;
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 // use std::iter::FromIterator;
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -118,12 +118,12 @@ fn delete() {
     }
 
     for e in entities.iter() {
-        assert_eq!(true, world.is_alive(e));
+        assert_eq!(true, world.is_alive(*e));
     }
 
     for e in entities.iter() {
         world.delete(*e);
-        assert_eq!(false, world.is_alive(e));
+        assert_eq!(false, world.is_alive(*e));
     }
 }
 
@@ -145,10 +145,10 @@ fn delete_last() {
 
     let last = *entities.last().unwrap();
     world.delete(last);
-    assert_eq!(false, world.is_alive(&last));
+    assert_eq!(false, world.is_alive(last));
 
     for (i, e) in entities.iter().take(entities.len() - 1).enumerate() {
-        assert_eq!(true, world.is_alive(e));
+        assert_eq!(true, world.is_alive(*e));
         match world.component(*e) {
             Some(x) => assert_eq!(components.get(i).map(|(x, _)| x), Some(&x as &Pos)),
             None => assert_eq!(components.get(i).map(|(x, _)| x), None),
@@ -179,10 +179,10 @@ fn delete_first() {
     let first = *entities.first().unwrap();
 
     world.delete(first);
-    assert_eq!(false, world.is_alive(&first));
+    assert_eq!(false, world.is_alive(first));
 
     for (i, e) in entities.iter().skip(1).enumerate() {
-        assert_eq!(true, world.is_alive(e));
+        assert_eq!(true, world.is_alive(*e));
         match world.component(*e) {
             Some(x) => assert_eq!(components.get(i + 1).map(|(x, _)| x), Some(&x as &Pos)),
             None => assert_eq!(components.get(i + 1).map(|(x, _)| x), None),
@@ -219,7 +219,7 @@ fn merge() {
     world_1.merge(world_2);
 
     for (i, e) in world_2_entities.iter().enumerate() {
-        assert!(world_1.is_alive(e));
+        assert!(world_1.is_alive(*e));
 
         let (pos, rot) = components.get(i).unwrap();
         assert_eq!(pos, &world_1.component(*e).unwrap() as &Pos);


### PR DESCRIPTION
This is strictly ergonomic changes. I went through the effort of getting Legion to completely pass a normal clippy pass. This included small changes like passing newtypes of primitives by value, some idiomatic changes to iterator usage (find instead of filter+next, etc) and some pointer arithmetic changes for clarity, and finally some derivative changes to be more in line with "Default is default" idiom.

This was mainly so i could begin work while actively using clippy on the repo.