### PR TITLE
preparatory commit for scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ itertools = "0.8"
 rayon = { version = "1.2", optional = true }
 derivative = "1"
 smallvec = "0.6"
+petgraph = "0.4"
+hibitset = "0.6"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -27,7 +27,7 @@ use std::slice::IterMut;
 
 /// A type ID identifying a component type.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
-pub struct ComponentTypeId(TypeId);
+pub struct ComponentTypeId(pub(crate) TypeId);
 
 impl ComponentTypeId {
     /// Gets the component type ID that represents type `T`.


### PR DESCRIPTION
This adds three accessors to the query View type:

type `Accessor` - just provides the type accessor for the view for easy typing referencing.

`read_types`/`write_types` - These are adding so the component id's of any given query can be retrieved. This is currently a `Vec` which requires allocation.

Dynamically retrieving the read and write types is needed to appropriately check what types are going to be used by any given query (and hence any given task/job)
