### PR TITLE
Test features individually in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,6 @@ cache: cargo
 script:
   - cargo test --all-features
   - cargo test --no-default-features
+  - cargo test --no-default-features --features events
+  - cargo test --no-default-features --features par-iter
+  - cargo test --no-default-features --features ffi


### PR DESCRIPTION
Ensures no accidental interdependencies arise.

This does in fact fail due to some existing interdependencies, and probably shouldn't be merged until they're fixed.