### PR TITLE
[WIP] Query random access APIs

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -106,7 +106,7 @@ fn bench_iter_simple(c: &mut Criterion) {
         let mut query = <(Read<Position>, Write<Rotation>)>::query();
 
         b.iter(|| {
-            for (pos, mut rot) in query.iter(&world) {
+            for (pos, mut rot) in query.iter(&mut world) {
                 rot.0 = pos.0;
             }
         });
@@ -129,7 +129,7 @@ fn bench_iter_complex(c: &mut Criterion) {
             .filter(!component::<A>() & tag_value(&Tag(2.0)));
 
         b.iter(|| {
-            for (pos, mut rot) in query.iter(&world) {
+            for (pos, mut rot) in query.iter(&mut world) {
                 rot.0 = pos.0;
             }
         });
@@ -144,7 +144,7 @@ fn bench_iter_chunks_simple(c: &mut Criterion) {
         let mut query = <(Write<Position>, Read<Rotation>)>::query();
 
         b.iter(|| {
-            for c in query.iter_chunks(&world) {
+            for c in query.iter_chunks(&mut world) {
                 unsafe {
                     c.components_mut::<Position>()
                         .unwrap()
@@ -172,7 +172,7 @@ fn bench_iter_chunks_complex(c: &mut Criterion) {
             .filter(!component::<A>() & tag_value(&Tag(2.0)));
 
         b.iter(|| {
-            for c in query.iter_chunks(&world) {
+            for c in query.iter_chunks(&mut world) {
                 unsafe {
                     c.components_mut::<Position>()
                         .unwrap()

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -58,27 +58,27 @@ fn ideal(data: &mut Vec<(Position, Orientation, Scale, Transform)>) {
     }
 }
 
-fn sequential(world: &World) {
+fn sequential(world: &mut World) {
     for (pos, orient, scale, mut trans) in <(
         Read<Position>,
         Read<Orientation>,
         Read<Scale>,
         Write<Transform>,
     )>::query()
-    .iter(&world)
+    .iter(world)
     {
         trans.0 = process(&pos.0, &orient.0, &scale.0);
     }
 }
 
-fn par_for_each(world: &World) {
+fn par_for_each(world: &mut World) {
     <(
         Read<Position>,
         Read<Orientation>,
         Read<Scale>,
         Write<Transform>,
     )>::query()
-    .par_for_each(&world, |(pos, orient, scale, mut trans)| {
+    .par_for_each(world, |(pos, orient, scale, mut trans)| {
         trans.0 = process(&pos.0, &orient.0, &scale.0);
     });
 }
@@ -96,13 +96,13 @@ fn bench_transform(c: &mut Criterion) {
         )
         .with_function("sequential", |b, n| {
             let data = data(*n);
-            let world = setup(data);
-            b.iter(|| sequential(&world));
+            let mut world = setup(data);
+            b.iter(|| sequential(&mut world));
         })
         .with_function("par_for_each", |b, n| {
             let data = data(*n);
-            let world = setup(data);
-            join(|| {}, || b.iter(|| par_for_each(&world)));
+            let mut world = setup(data);
+            join(|| {}, || b.iter(|| par_for_each(&mut world)));
         }),
     );
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -23,7 +23,7 @@ fn main() {
 
     // update positions
     let mut query = <(Write<Pos>, Read<Vel>)>::query();
-    for (mut pos, vel) in query.iter(&world) {
+    for (mut pos, vel) in query.iter(&mut world) {
         pos.0 += vel.0;
         pos.1 += vel.1;
         pos.2 += vel.2;
@@ -33,7 +33,7 @@ fn main() {
     let mut query = <(Write<Pos>, Read<Vel>)>::query();
     #[cfg(feature = "par-iter")]
     {
-        query.par_for_each(&world, |(mut pos, vel)| {
+        query.par_for_each(&mut world, |(mut pos, vel)| {
             pos.0 += vel.0;
             pos.1 += vel.1;
             pos.2 += vel.2;
@@ -42,7 +42,7 @@ fn main() {
 
     #[cfg(not(feature = "par-iter"))]
     {
-        query.for_each(&world, |(mut pos, vel)| {
+        query.for_each(&mut world, |(mut pos, vel)| {
             pos.0 += vel.0;
             pos.1 += vel.1;
             pos.2 += vel.2;

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ let entities: &[Entity] = world.insert(
 let query = <(Write<Position>, Read<Velocity>)>::query();
 
 // Iterate through all entities that match the query in the world
-for (mut pos, vel) in query.iter(&world) {
+for (mut pos, vel) in query.iter(&mut world) {
     pos.x += vel.dx;
     pos.y += vel.dy;
 }
@@ -83,7 +83,7 @@ Additional data type filters:
 // It is possible to specify that entities must contain data beyond that being fetched
 let query = Read::<Position>::query()
     .filter(component::<Velocity>());
-for position in query.iter(&world) {
+for position in query.iter(&mut world) {
     // these entities also have `Velocity`
 }
 ```
@@ -94,7 +94,7 @@ Filter boolean operations:
 // Filters can be combined with boolean operators
 let query = Read::<Position>::query()
     .filter(tag::<Static>() | !component::<Velocity>());
-for position in query.iter(&world) {
+for position in query.iter(&mut world) {
     // these entities are also either marked as `Static`, or do *not* have a `Velocity`
 }
 ```
@@ -105,7 +105,7 @@ Filter by shared data value:
 // Filters can filter by specific shared data values
 let query = Read::<Position>::query()
     .filter(tag_value(&Model(3)));
-for position in query.iter(&world) {
+for position in query.iter(&mut world) {
     // these entities all have shared data value `Model(3)`
 }
 ```
@@ -117,7 +117,7 @@ Change detection:
 // has not changed since the last time the query was iterated.
 let query = <(Read<Position>, Shared<Model>)>::query()
     .filter(changed::<Position>());
-for (pos, model) in query.iter(&world) {
+for (pos, model) in query.iter(&mut world) {
     // entities who have changed position
 }
 ```
@@ -151,7 +151,7 @@ fn render_instanced(model: &Model, transforms: &[Transform]) {
 let query = Read::<Transform>::query()
     .filter(tag::<Model>());
 
-for chunk in query.iter_chunks(&world) {
+for chunk in query.iter_chunks(&mut world) {
     // get the chunk's model
     let model: &Model = chunk.tag().unwrap();
 

--- a/src/accessor.rs
+++ b/src/accessor.rs
@@ -1,0 +1,182 @@
+//! Entity accessor types, used to access  arbitrary components for an entity.
+
+use crate::entity::{EntityLocation, Entity};
+use crate::storage::{ComponentStorage, Component, ComponentTypeId};
+use crate::world::World;
+use crate::borrow::{Ref, Shared, RefMut, Exclusive};
+use std::ops::Deref;
+
+struct EntityAccessorInner<'data> {
+    location: EntityLocation,
+    entity: Entity,
+    chunk: &'data ComponentStorage,
+}
+
+impl <'data> EntityAccessorInner<'data> {
+    fn new(world: &'data World, entity: Entity) -> Option<Self> {
+        if !world.is_alive(entity) {
+            return None;
+        }
+
+        let location = world.entity_allocator.get_location(entity.index())?;
+        let archetype = world.storage().archetypes().get(location.archetype())?;
+        let chunk = archetype
+            .chunksets()
+            .get(location.set())?
+            .get(location.chunk())?;
+
+        Some(Self {
+            location,
+            entity,
+            chunk,
+        })
+    }
+
+    fn get<T: Component>(&self) -> Option<Ref<'data, Shared, T>> {
+        let (slice_borrow, slice) = unsafe {
+            self.chunk
+                .components(ComponentTypeId::of::<T>())?
+                .data_slice::<T>()
+                .deconstruct()
+        };
+        let component = slice.get(self.location.component())?;
+
+        Some(Ref::new(slice_borrow, component))
+    }
+
+    unsafe fn get_mut_unchecked<T: Component>(&self) -> Option<RefMut<'data, Exclusive, T>> {
+        let (slice_borrow, slice) = self.chunk
+                .components(ComponentTypeId::of::<T>())?
+                .data_slice_mut::<T>()
+                .deconstruct();
+        let component = slice.get_mut(self.location.component())?;
+
+        Some(RefMut::new(slice_borrow, component))
+    }
+}
+
+/// An entity accessor.
+///
+/// This type can be used to access arbitrary components
+/// for a given entity through a query. It can be obtained
+/// through `Query::find_accessor` and `World::get_accessor`.
+///
+/// This type is useful if, for example, you want to pass
+/// an entity and all its components to a function without
+/// knowing which components need to be accessed.
+///
+/// Note that this type only provides immutable access to components; if you
+/// would like mutable access, see `EntityAccessorMut`.
+pub struct EntityAccessor<'data> {
+    inner: EntityAccessorInner<'data>,
+}
+
+impl <'data> EntityAccessor<'data> {
+    pub(crate) fn new(world: &'data World, entity: Entity) -> Option<Self> {
+        Some(Self {
+            inner: EntityAccessorInner::new(world, entity)?,
+        })
+    }
+
+    /// Retrieves a component for this entity, returning it. Returns
+    /// `None` if the entity does not have this component.
+    pub fn get<T: Component>(&self) -> Option<Ref<'data, Shared, T>> {
+        self.inner.get()
+    }
+
+    /// Returns the entity accessed by this `EntityAccessor`.
+    pub fn entity(&self) -> Entity {
+        self.inner.entity
+    }
+}
+
+/// A mutable entity accessor.
+///
+/// This type can be used to access arbitrary components
+/// for a given entity through a query. It can be obtained
+/// through `Query::find_accessor_mut` and `World::get_acessor_mut`.
+///
+/// This type is useful if, for example, you want to pass
+/// an entity and all its components to a function without
+/// knowing which components need to be accessed.
+///
+/// Unlike `EntityAccessor`, this type allows mutable access to components.
+pub struct EntityAccessorMut<'data> {
+    // We store an immutable accessor so we can deref
+    // to `EntityAccessor`. This allows users to pass
+    // an `EntityAccessorMut` to a function accepting
+    // `&EntityAccessor`.
+    inner: EntityAccessor<'data>,
+}
+
+impl <'data> EntityAccessorMut<'data> {
+    pub(crate) unsafe fn new(world: &'data World, entity: Entity) -> Option<Self> {
+        Some(Self {
+            inner: EntityAccessor::new(world, entity)?,
+        })
+    }
+
+    /// Retrieves a component for this entity, returning it. Returns
+    /// `None` if the entity does not have this component.
+    pub fn get<T: Component>(&self) -> Option<Ref<'data, Shared, T>> {
+        self.inner.get()
+    }
+
+    /// Mutably retrieves a component for this entity, returning it. Returns
+    /// `None` if the entity does not have this component.
+    pub fn get_mut<T: Component>(&mut self) -> Option<RefMut<'data, Exclusive, T>> {
+        // Safety: mutable access to `self` ensures uniqueness of borrowed
+        // component.
+        unsafe { self.inner.inner.get_mut_unchecked() }
+    }
+
+    /// Mutably retrieves a component for this entity, returning it. Returns
+    /// `None` if the entity does not have this component.
+    ///
+    /// # Safety
+    /// No runtime checks are performed to ensure that the reference to the
+    /// component is exclusive. Having multiple mutable references to the
+    /// same component is undefined behavior.
+    ///
+    /// Unlike `get_mut``, this function does not require mutable access to `self`,
+    /// so the compiler does not catch safety issues,
+    pub unsafe fn get_mut_unchecked<T: Component>(&self) -> Option<RefMut<'data, Exclusive, T>> {
+        self.inner.inner.get_mut_unchecked()
+    }
+
+    /// Returns the entity accessed by this `EntityAccessor`.
+    pub fn entity(&self) -> Entity {
+        self.inner.entity()
+    }
+}
+
+impl <'data> Deref for EntityAccessorMut<'data> {
+    type Target = EntityAccessor<'data>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::world::Universe;
+
+    #[test]
+    fn accessor() {
+        let universe = Universe::new();
+        let mut world = universe.create_world();
+
+        let entity = world.insert((), vec![("test", 1)])[0];
+        let accessor = world.get_accessor(entity).unwrap();
+
+        assert_eq!(*accessor.get::<&'static str>().unwrap(), "test");
+        assert_eq!(*accessor.get::<i32>().unwrap(), 1);
+
+        let mut accessor = world.get_accessor_mut(entity).unwrap();
+
+        *accessor.get_mut::<i32>().unwrap() += 1;
+
+        assert_eq!(*world.get_component::<i32>(entity).unwrap(), 2);
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -378,7 +378,7 @@ mod tests {
         let mut query = Read::<Pos>::query();
 
         let mut count = 0;
-        for _ in query.iter_entities(&world) {
+        for _ in query.iter_entities(&mut world) {
             count += 1;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //! let mut query = <(Write<Position>, Read<Velocity>)>::query();
 //!
 //! // Iterate through all entities that match the query in the world
-//! for (mut pos, vel) in query.iter(&world) {
+//! for (mut pos, vel) in query.iter(&mut world) {
 //!     pos.x += vel.dx;
 //!     pos.y += vel.dy;
 //! }
@@ -82,7 +82,7 @@
 //! // It is possible to specify that entities must contain data beyond that being fetched
 //! let mut query = Read::<Position>::query()
 //!     .filter(component::<Velocity>());
-//! for position in query.iter(&world) {
+//! for position in query.iter(&mut world) {
 //!     // these entities also have `Velocity`
 //! }
 //! ```
@@ -110,7 +110,7 @@
 //! // Filters can be combined with boolean operators
 //! let mut query = Read::<Position>::query()
 //!     .filter(tag::<Static>() | !component::<Velocity>());
-//! for position in query.iter(&world) {
+//! for position in query.iter(&mut world) {
 //!     // these entities are also either marked as `Static`, or do *not* have a `Velocity`
 //! }
 //! ```
@@ -138,7 +138,7 @@
 //! // Filters can filter by specific tag values
 //! let mut query = Read::<Position>::query()
 //!     .filter(tag_value(&Model(3)));
-//! for position in query.iter(&world) {
+//! for position in query.iter(&mut world) {
 //!     // these entities all have tag value `Model(3)`
 //! }
 //! ```
@@ -167,7 +167,7 @@
 //! // has not changed since the last time the query was iterated.
 //! let mut query = <(Read<Position>, Tagged<Model>)>::query()
 //!     .filter(changed::<Position>());
-//! for (pos, model) in query.iter(&world) {
+//! for (pos, model) in query.iter(&mut world) {
 //!     // entities who have changed position
 //! }
 //! ```
@@ -209,7 +209,7 @@
 //! let mut query = Read::<Transform>::query()
 //!     .filter(tag::<Model>());
 //!
-//! for chunk in query.iter_chunks(&world) {
+//! for chunk in query.iter_chunks(&mut world) {
 //!     // get the chunk's model
 //!     let model: &Model = chunk.tag().unwrap();
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,6 +222,7 @@
 //! ```
 #![allow(dead_code)]
 
+pub mod accessor;
 pub mod borrow;
 pub mod command;
 pub mod entity;

--- a/src/query.rs
+++ b/src/query.rs
@@ -694,12 +694,12 @@ where
 /// # #[derive(Copy, Clone, Debug, PartialEq)]
 /// # struct Model;
 /// # let universe = Universe::new();
-/// # let world = universe.create_world();
+/// # let mut world = universe.create_world();
 /// // A query which writes `Position`, reads `Velocity` and reads `Model`
 /// // Tags are read-only, and is distinguished from entity data reads with `Tagged<T>`.
 /// let mut query = <(Write<Position>, Read<Velocity>, Tagged<Model>)>::query();
 ///
-/// for (mut pos, vel, model) in query.iter(&world) {
+/// for (mut pos, vel, model) in query.iter(&mut world) {
 ///     // `.iter` yields tuples of references to a single entity's data:
 ///     // pos: &mut Position
 ///     // vel: &Velocity
@@ -719,10 +719,10 @@ where
 /// # #[derive(Copy, Clone, Debug, PartialEq)]
 /// # struct Model;
 /// # let universe = Universe::new();
-/// # let world = universe.create_world();
+/// # let mut world = universe.create_world();
 /// let mut query = <(Write<Position>, Read<Velocity>, Tagged<Model>)>::query();
 ///
-/// for chunk in query.iter_chunks(&world) {
+/// for chunk in query.iter_chunks(&mut world) {
 ///     let model = chunk.tag::<Model>();
 ///     let positions = chunk.components_mut::<Position>();
 ///     let velocities = chunk.components::<Velocity>();
@@ -757,7 +757,16 @@ where
     }
 
     /// Gets an iterator which iterates through all chunks that match the query.
-    pub fn iter_chunks<'a, 'data>(
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    pub unsafe fn iter_chunks_unchecked<'a, 'data>(
         &'a mut self,
         world: &'data World,
     ) -> ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter> {
@@ -781,8 +790,26 @@ where
         }
     }
 
+    /// Gets an iterator which iterates through all chunks that match the query.
+    pub fn iter_chunks<'a, 'data>(
+        &'a mut self,
+        world: &'data mut World,
+    ) -> ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter> {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.iter_chunks_unchecked(world) }
+    }
+
     /// Gets an iterator which iterates through all entity data that matches the query, and also yields the the `Entity` IDs.
-    pub fn iter_entities<'a, 'data>(
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    pub unsafe fn iter_entities_unchecked<'a, 'data>(
         &'a mut self,
         world: &'data World,
     ) -> ChunkEntityIter<
@@ -791,14 +818,36 @@ where
         ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
     > {
         ChunkEntityIter {
-            iter: self.iter_chunks(world),
+            iter: self.iter_chunks_unchecked(world),
             frontier: None,
             _view: PhantomData,
         }
     }
 
+    /// Gets an iterator which iterates through all entity data that matches the query, and also yields the the `Entity` IDs.
+    pub fn iter_entities<'a, 'data>(
+        &'a mut self,
+        world: &'data mut World,
+    ) -> ChunkEntityIter<
+        'data,
+        V,
+        ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
+    > {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.iter_entities_unchecked(world) }
+    }
+
     /// Gets an iterator which iterates through all entity data that matches the query.
-    pub fn iter<'a, 'data>(
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    pub unsafe fn iter_unchecked<'a, 'data>(
         &'a mut self,
         world: &'data World,
     ) -> ChunkDataIter<
@@ -807,31 +856,92 @@ where
         ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
     > {
         ChunkDataIter {
-            iter: self.iter_chunks(world),
+            iter: self.iter_chunks_unchecked(world),
             frontier: None,
             _view: PhantomData,
         }
     }
 
-    /// Iterates through all entity data that matches the query.
-    pub fn for_each_entities<'a, 'data, T>(&'a mut self, world: &'data World, mut f: T)
-    where
-        T: Fn((Entity, <<V as View<'data>>::Iter as Iterator>::Item)),
-    {
-        self.iter_entities(world).for_each(&mut f);
+    /// Gets an iterator which iterates through all entity data that matches the query.
+    pub fn iter<'a, 'data>(
+        &'a mut self,
+        world: &'data mut World,
+    ) -> ChunkDataIter<
+        'data,
+        V,
+        ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
+    > {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.iter_unchecked(world) }
     }
 
     /// Iterates through all entity data that matches the query.
-    pub fn for_each<'a, 'data, T>(&'a mut self, world: &'data World, mut f: T)
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    pub unsafe fn for_each_entities_unchecked<'a, 'data, T>(
+        &'a mut self,
+        world: &'data World,
+        mut f: T,
+    ) where
+        T: Fn((Entity, <<V as View<'data>>::Iter as Iterator>::Item)),
+    {
+        self.iter_entities_unchecked(world).for_each(&mut f);
+    }
+
+    /// Iterates through all entity data that matches the query.
+    pub fn for_each_entities<'a, 'data, T>(&'a mut self, world: &'data mut World, f: T)
+    where
+        T: Fn((Entity, <<V as View<'data>>::Iter as Iterator>::Item)),
+    {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.for_each_entities_unchecked(world, f) };
+    }
+
+    /// Iterates through all entity data that matches the query.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    pub unsafe fn for_each_unchecked<'a, 'data, T>(&'a mut self, world: &'data World, mut f: T)
     where
         T: Fn(<<V as View<'data>>::Iter as Iterator>::Item),
     {
-        self.iter(world).for_each(&mut f);
+        self.iter_unchecked(world).for_each(&mut f);
+    }
+
+    /// Iterates through all entity data that matches the query.
+    pub fn for_each<'a, 'data, T>(&'a mut self, world: &'data mut World, f: T)
+    where
+        T: Fn(<<V as View<'data>>::Iter as Iterator>::Item),
+    {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.for_each_unchecked(world, f) };
     }
 
     #[cfg(feature = "par-iter")]
     /// Gets an iterator which iterates through all chunks that match the query in parallel.
-    pub fn par_iter_chunks<'a, 'data>(
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    pub unsafe fn par_iter_chunks_unchecked<'a, 'data>(
         &'a mut self,
         world: &'data World,
     ) -> ChunkViewParIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>
@@ -858,16 +968,40 @@ where
         }
     }
 
-    /// Iterates through all entity data that matches the query in parallel.
     #[cfg(feature = "par-iter")]
-    pub fn par_entities_for_each<'a, T>(&'a mut self, world: &'a World, f: T)
+    /// Gets an iterator which iterates through all chunks that match the query in parallel.
+    pub fn par_iter_chunks<'a, 'data>(
+        &'a mut self,
+        world: &'data mut World,
+    ) -> ChunkViewParIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>
+    where
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'data>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'data>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'data>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.par_iter_chunks_unchecked(world) }
+    }
+
+    /// Iterates through all entity data that matches the query in parallel.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    #[cfg(feature = "par-iter")]
+    pub unsafe fn par_entities_for_each_unchecked<'a, T>(&'a mut self, world: &'a World, f: T)
     where
         T: Fn((Entity, <<V as View<'a>>::Iter as Iterator>::Item)) + Send + Sync,
         <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
     {
-        self.par_for_each_chunk(world, |mut chunk| {
+        self.par_for_each_chunk_unchecked(world, |mut chunk| {
             for data in chunk.iter_entities() {
                 f(data);
             }
@@ -876,33 +1010,90 @@ where
 
     /// Iterates through all entity data that matches the query in parallel.
     #[cfg(feature = "par-iter")]
-    pub fn par_for_each<'a, T>(&'a mut self, world: &'a World, f: T)
+    pub fn par_entities_for_each<'a, T>(&'a mut self, world: &'a mut World, f: T)
+    where
+        T: Fn((Entity, <<V as View<'a>>::Iter as Iterator>::Item)) + Send + Sync,
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.par_entities_for_each_unchecked(world, f) };
+    }
+
+    /// Iterates through all entity data that matches the query in parallel.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    #[cfg(feature = "par-iter")]
+    pub unsafe fn par_for_each_unchecked<'a, T>(&'a mut self, world: &'a World, f: T)
     where
         T: Fn(<<V as View<'a>>::Iter as Iterator>::Item) + Send + Sync,
         <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
     {
-        self.par_for_each_chunk(world, |mut chunk| {
+        self.par_for_each_chunk_unchecked(world, |mut chunk| {
             for data in chunk.iter() {
                 f(data);
             }
         });
     }
 
-    /// Iterates through all chunks that match the query in parallel.
+    /// Iterates through all entity data that matches the query in parallel.
     #[cfg(feature = "par-iter")]
-    pub fn par_for_each_chunk<'a, T>(&'a mut self, world: &'a World, f: T)
+    pub fn par_for_each<'a, T>(&'a mut self, world: &'a mut World, f: T)
+    where
+        T: Fn(<<V as View<'a>>::Iter as Iterator>::Item) + Send + Sync,
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.par_for_each_unchecked(world, f) };
+    }
+
+    /// Iterates through all chunks that match the query in parallel.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    #[cfg(feature = "par-iter")]
+    pub unsafe fn par_for_each_chunk_unchecked<'a, T>(&'a mut self, world: &'a World, f: T)
     where
         T: Fn(Chunk<'a, V>) + Send + Sync,
         <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
     {
-        let par_iter = self.par_iter_chunks(world);
+        let par_iter = self.par_iter_chunks_unchecked(world);
         ParallelIterator::for_each(par_iter, |chunk| {
             f(chunk);
         });
+    }
+
+    /// Iterates through all chunks that match the query in parallel.
+    #[cfg(feature = "par-iter")]
+    pub fn par_for_each_chunk<'a, T>(&'a mut self, world: &'a mut World, f: T)
+    where
+        T: Fn(Chunk<'a, V>) + Send + Sync,
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut World ensures exclusivity
+        unsafe { self.par_for_each_chunk_unchecked(world, f) };
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -10,7 +10,9 @@ use crate::query::{
     Chunk, ChunkDataIter, ChunkEntityIter, ChunkViewIter, Query, Read, View, Write,
 };
 use crate::resource::{Resource, ResourceSet, ResourceTypeId};
+use crate::schedule::ArchetypeAccess;
 use crate::schedule::{Runnable, Schedulable};
+use crate::storage::Tag;
 use crate::storage::{Component, ComponentTypeId, TagTypeId};
 use crate::world::World;
 use bit_set::BitSet;
@@ -51,7 +53,6 @@ where
     V: for<'v> View<'v>,
     F: EntityFilter,
 {
-    world: *const World,
     query: *mut Query<V, F>,
 }
 
@@ -68,9 +69,8 @@ where
     F: EntityFilter,
 {
     /// Safety: input references might not outlive a created instance of `PreparedQuery`.
-    unsafe fn new(world: &World, query: &mut Query<V, F>) -> Self {
+    unsafe fn new(query: &mut Query<V, F>) -> Self {
         Self {
-            world: world as *const World,
             query: query as *mut Query<V, F>,
         }
     }
@@ -79,93 +79,273 @@ where
     // in user's hands and access to internal pointers is impossible. There is no way to move the object out
     // of mutable reference through public API, because there is no way to get access to more than a single instance at a time.
     // The unsafety is an implementation detail. It can be fully safe once GATs are in the language.
+
     /// Gets an iterator which iterates through all chunks that match the query.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
     #[inline]
+    pub unsafe fn iter_chunks_unchecked<'a, 'b>(
+        &'b mut self,
+        world: &PreparedWorld,
+    ) -> ChunkViewIter<'a, 'b, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter> {
+        (&mut *self.query).iter_chunks_unchecked(&*world.world)
+    }
+
+    /// Gets an iterator which iterates through all chunks that match the query.
     pub fn iter_chunks<'a, 'b>(
         &'b mut self,
+        world: &mut PreparedWorld,
     ) -> ChunkViewIter<'a, 'b, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter> {
-        unsafe { (&mut *self.query).iter_chunks(&*self.world) }
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.iter_chunks_unchecked(world) }
+    }
+
+    /// Gets an iterator which iterates through all entity data that matches the query, and also yields the the `Entity` IDs.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    #[inline]
+    pub unsafe fn iter_entities_unchecked<'a, 'b>(
+        &'b mut self,
+        world: &PreparedWorld,
+    ) -> ChunkEntityIter<
+        'a,
+        V,
+        ChunkViewIter<'a, 'b, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
+    > {
+        (&mut *self.query).iter_entities_unchecked(&*world.world)
     }
 
     /// Gets an iterator which iterates through all entity data that matches the query, and also yields the the `Entity` IDs.
     #[inline]
     pub fn iter_entities<'a, 'b>(
         &'b mut self,
+        world: &mut PreparedWorld,
     ) -> ChunkEntityIter<
         'a,
         V,
         ChunkViewIter<'a, 'b, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
     > {
-        unsafe { (&mut *self.query).iter_entities(&*self.world) }
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.iter_entities_unchecked(world) }
+    }
+
+    /// Gets an iterator which iterates through all entity data that matches the query.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    #[inline]
+    pub unsafe fn iter_unchecked<'a, 'data>(
+        &'a mut self,
+        world: &PreparedWorld,
+    ) -> ChunkDataIter<
+        'data,
+        V,
+        ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
+    > {
+        (&mut *self.query).iter_unchecked(&*world.world)
     }
 
     /// Gets an iterator which iterates through all entity data that matches the query.
     #[inline]
     pub fn iter<'a, 'data>(
         &'a mut self,
+        world: &mut PreparedWorld,
     ) -> ChunkDataIter<
         'data,
         V,
         ChunkViewIter<'data, 'a, V, F::ArchetypeFilter, F::ChunksetFilter, F::ChunkFilter>,
     > {
-        unsafe { (&mut *self.query).iter(&*self.world) }
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.iter_unchecked(world) }
     }
 
     /// Iterates through all entity data that matches the query.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
     #[inline]
-    pub fn for_each<'a, 'data, T>(&'a mut self, f: T)
+    pub unsafe fn for_each_unchecked<'a, 'data, T>(&'a mut self, world: &PreparedWorld, f: T)
     where
         T: Fn(<<V as View<'data>>::Iter as Iterator>::Item),
     {
-        unsafe { (&mut *self.query).for_each(&*self.world, f) }
+        (&mut *self.query).for_each_unchecked(&*world.world, f)
+    }
+
+    /// Iterates through all entity data that matches the query.
+    #[inline]
+    pub fn for_each<'a, 'data, T>(&'a mut self, world: &mut PreparedWorld, f: T)
+    where
+        T: Fn(<<V as View<'data>>::Iter as Iterator>::Item),
+    {
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.for_each_unchecked(world, f) }
+    }
+
+    /// Iterates through all entity data that matches the query.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
+    #[cfg(feature = "par-iter")]
+    #[inline]
+    pub unsafe fn for_each_entities_unchecked<'a, 'data, T>(
+        &'a mut self,
+        world: &PreparedWorld,
+        f: T,
+    ) where
+        T: Fn((Entity, <<V as View<'data>>::Iter as Iterator>::Item)),
+    {
+        (&mut *self.query).for_each_entities_unchecked(&*world.world, f)
     }
 
     /// Iterates through all entity data that matches the query.
     #[cfg(feature = "par-iter")]
-    pub fn for_each_entities<'a, 'data, T>(&'a mut self, f: T)
+    #[inline]
+    pub fn for_each_entities<'a, 'data, T>(&'a mut self, world: &mut PreparedWorld, f: T)
     where
         T: Fn((Entity, <<V as View<'data>>::Iter as Iterator>::Item)),
     {
-        unsafe { (&mut *self.query).for_each_entities(&*self.world, f) }
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.for_each_entities_unchecked(world, f) }
     }
 
-    /// Iterates through all entities that matches the query in parallel by chunk
+    /// Iterates through all entities that matches the query in parallel by chunk.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
     #[cfg(feature = "par-iter")]
     #[inline]
-    pub fn par_entities_for_each<'a, T>(&'a mut self, f: T)
+    pub unsafe fn par_entities_for_each_unchecked<'a, T>(&'a mut self, world: &PreparedWorld, f: T)
     where
         T: Fn((Entity, <<V as View<'a>>::Iter as Iterator>::Item)) + Send + Sync,
         <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
     {
-        unsafe { (&mut *self.query).par_entities_for_each(&*self.world, f) }
+        (&mut *self.query).par_entities_for_each_unchecked(&*world.world, f)
+    }
+
+    /// Iterates through all entities that matches the query in parallel by chunk.
+    #[cfg(feature = "par-iter")]
+    #[inline]
+    pub fn par_entities_for_each<'a, T>(&'a mut self, world: &mut PreparedWorld, f: T)
+    where
+        T: Fn((Entity, <<V as View<'a>>::Iter as Iterator>::Item)) + Send + Sync,
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.par_entities_for_each_unchecked(world, f) }
     }
 
     /// Iterates through all entity data that matches the query in parallel.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
     #[cfg(feature = "par-iter")]
     #[inline]
-    pub fn par_for_each<'a, T>(&'a mut self, f: T)
+    pub unsafe fn par_for_each_unchecked<'a, T>(&'a mut self, world: &PreparedWorld, f: T)
     where
         T: Fn(<<V as View<'a>>::Iter as Iterator>::Item) + Send + Sync,
         <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
     {
-        unsafe { (&mut *self.query).par_for_each(&*self.world, f) }
+        (&mut *self.query).par_for_each_unchecked(&*world.world, f)
+    }
+
+    /// Iterates through all entity data that matches the query in parallel.
+    #[cfg(feature = "par-iter")]
+    #[inline]
+    pub fn par_for_each<'a, T>(&'a mut self, world: &mut PreparedWorld, f: T)
+    where
+        T: Fn(<<V as View<'a>>::Iter as Iterator>::Item) + Send + Sync,
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.par_for_each_unchecked(world, f) }
     }
 
     /// Gets a parallel iterator of chunks that match the query.
+    /// Does not perform static borrow checking.
+    ///
+    /// # Safety
+    ///
+    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if other code is concurrently accessing the same components.
     #[cfg(feature = "par-iter")]
     #[inline]
-    pub fn par_for_each_chunk<'a, T>(&'a mut self, f: T)
+    pub unsafe fn par_for_each_chunk_unchecked<'a, T>(&'a mut self, world: &PreparedWorld, f: T)
     where
         T: Fn(Chunk<'a, V>) + Send + Sync,
         <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
         <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
     {
-        unsafe { (&mut *self.query).par_for_each_chunk(&*self.world, f) }
+        (&mut *self.query).par_for_each_chunk_unchecked(&*world.world, f)
+    }
+
+    /// Gets a parallel iterator of chunks that match the query.
+    #[cfg(feature = "par-iter")]
+    #[inline]
+    pub fn par_for_each_chunk<'a, T>(&'a mut self, world: &mut PreparedWorld, f: T)
+    where
+        T: Fn(Chunk<'a, V>) + Send + Sync,
+        <F::ArchetypeFilter as Filter<ArchetypeFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunksetFilter as Filter<ChunksetFilterData<'a>>>::Iter: FissileIterator,
+        <F::ChunkFilter as Filter<ChunkFilterData<'a>>>::Iter: FissileIterator,
+    {
+        // safe because the &mut PreparedWorld ensures exclusivity
+        unsafe { self.par_for_each_chunk_unchecked(world, f) }
     }
 }
 
@@ -182,7 +362,7 @@ pub trait QuerySet: Send + Sync {
     /// # Safety
     /// prepare call doesn't respect lifetimes of `self` and `world`.
     /// The returned value cannot outlive them.
-    unsafe fn prepare(&mut self, world: &World) -> Self::PreparedQueries;
+    unsafe fn prepare(&mut self) -> Self::PreparedQueries;
     // fn unprepare(prepared: Self::PreparedQueries) -> Self;
 }
 
@@ -204,9 +384,9 @@ macro_rules! impl_queryset_tuple {
                         $ty.filter.iter_archetype_indexes(storage).for_each(|id| { bitset.insert(id); });
                     )*
                 }
-                unsafe fn prepare(&mut self, world: &World) -> Self::PreparedQueries {
+                unsafe fn prepare(&mut self) -> Self::PreparedQueries {
                     let ($($ty,)*) = self;
-                    ($(PreparedQuery::<[<$ty V>], [<$ty F>]>::new(world, $ty),)*)
+                    ($(PreparedQuery::<[<$ty V>], [<$ty F>]>::new($ty),)*)
                 }
             }
         }
@@ -216,7 +396,7 @@ macro_rules! impl_queryset_tuple {
 impl QuerySet for () {
     type PreparedQueries = ();
     fn filter_archetypes(&mut self, _: &World, _: &mut BitSet) {}
-    unsafe fn prepare(&mut self, _: &World) {}
+    unsafe fn prepare(&mut self) {}
 }
 
 impl<AV, AF> QuerySet for Query<AV, AF>
@@ -231,9 +411,7 @@ where
             bitset.insert(id);
         });
     }
-    unsafe fn prepare(&mut self, world: &World) -> Self::PreparedQueries {
-        PreparedQuery::<AV, AF>::new(world, self)
-    }
+    unsafe fn prepare(&mut self) -> Self::PreparedQueries { PreparedQuery::<AV, AF>::new(self) }
 }
 
 impl_queryset_tuple!(A);
@@ -269,12 +447,22 @@ impl_queryset_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T,
 pub struct PreparedWorld {
     world: *const World,
     access: *const Access<ComponentTypeId>,
+    archetypes: Option<*const BitSet>,
 }
 impl PreparedWorld {
-    unsafe fn new(world: &World, access: &Access<ComponentTypeId>) -> Self {
+    unsafe fn new(
+        world: &World,
+        access: &Access<ComponentTypeId>,
+        archetypes: &ArchetypeAccess,
+    ) -> Self {
         Self {
             world: world as *const World,
             access: access as *const Access<ComponentTypeId>,
+            archetypes: if let ArchetypeAccess::Some(ref bitset) = archetypes {
+                Some(bitset as *const BitSet)
+            } else {
+                None
+            },
         }
     }
 }
@@ -284,6 +472,45 @@ unsafe impl Send for PreparedWorld {}
 
 // TODO: these assertions should have better errors
 impl PreparedWorld {
+    fn validate_archetype_access(&self, entity: Entity) -> bool {
+        unsafe {
+            if let Some(archetypes) = self.archetypes {
+                if let Some(location) = (*self.world).entity_allocator.get_location(entity.index())
+                {
+                    return (*archetypes).contains(location.archetype());
+                }
+            }
+        }
+
+        true
+    }
+
+    fn validate_reads<T: Component>(&self, entity: Entity) {
+        unsafe {
+            if !(*self.access).reads.contains(&ComponentTypeId::of::<T>())
+                || !self.validate_archetype_access(entity)
+            {
+                panic!("Attempted to read a component that this system does not have declared access to. \
+                Consider adding a query which contains `{}` and this entity in its result set to the system, \
+                or use `SystemBuilder::read_component` to declare global access.",
+                std::any::type_name::<T>());
+            }
+        }
+    }
+
+    fn validate_writes<T: Component>(&self, entity: Entity) {
+        unsafe {
+            if !(*self.access).writes.contains(&ComponentTypeId::of::<T>())
+                || !self.validate_archetype_access(entity)
+            {
+                panic!("Attempted to write to a component that this system does not have declared access to. \
+                Consider adding a query which contains `{}` and this entity in its result set to the system, \
+                or use `SystemBuilder::write_component` to declare global access.",
+                std::any::type_name::<T>());
+            }
+        }
+    }
+
     /// Borrows component data for the given entity.
     ///
     /// Returns `Some(data)` if the entity was found and contains the specified data.
@@ -291,44 +518,64 @@ impl PreparedWorld {
     ///
     /// # Panics
     ///
-    /// This function borrows all components of type `T` in the world. It may panic if
-    /// any other code is currently borrowing `T` mutable or if the component was not declared
-    /// as written by this system.
+    /// This function may panic if the component was not declared as read by this system.
     #[inline]
     pub fn get_component<T: Component>(&self, entity: Entity) -> Option<Ref<Shared, T>> {
-        if !unsafe { (&*self.access) }
-            .reads
-            .contains(&ComponentTypeId::of::<T>())
-        {
-            panic!("You attempted to fetch a component which was not declared with `read_component` on the system. \
-            Use SystemBuilder::read_component to add this access to: {}", std::any::type_name::<T>())
-        }
-
-        unsafe { (&*self.world) }.get_component::<T>(entity)
+        self.validate_reads::<T>(entity);
+        unsafe { (*self.world).get_component::<T>(entity) }
     }
 
-    /// Borrows component data for the given entity.
+    /// Borrows component data for the given entity. Does not perform static borrow checking.
+    ///
+    /// Returns `Some(data)` if the entity was found and contains the specified data.
+    /// Otherwise `None` is returned.
+    ///
+    /// # Safety
+    ///
+    /// Accessing a component which is already being concurrently accessed elsewhere is undefined behavior.
+    ///
+    /// # Panics
+    ///
+    /// This function may panic if any other code is currently borrowing `T` mutable or if the component was not declared
+    /// as written by this system.
+    #[inline]
+    pub unsafe fn get_component_mut_unchecked<T: Component>(
+        &self,
+        entity: Entity,
+    ) -> Option<RefMut<Exclusive, T>> {
+        self.validate_writes::<T>(entity);
+        (*self.world).get_component_mut_unchecked::<T>(entity)
+    }
+
+    /// Mutably borrows entity data for the given entity.
     ///
     /// Returns `Some(data)` if the entity was found and contains the specified data.
     /// Otherwise `None` is returned.
     ///
     /// # Panics
     ///
-    /// This function borrows all components of type `T` in the world. It may panic if
-    /// any other code is currently borrowing `T` mutable or if the component was not declared
-    /// as written by this system.
+    /// This function may panic if the component was not declared as written by this system.
     #[inline]
-    pub fn get_component_mut<T: Component>(&self, entity: Entity) -> Option<RefMut<Exclusive, T>> {
-        if !unsafe { (&*self.access) }
-            .writes
-            .contains(&ComponentTypeId::of::<T>())
-        {
-            panic!("You attempted to fetch a mutable component which was not declared with `write_component` on the system. \
-            Use SystemBuilder::write_component to add this access to: {}", std::any::type_name::<T>())
-        }
-
-        unsafe { (&*self.world) }.get_component_mut::<T>(entity)
+    pub fn get_component_mut<T: Component>(
+        &mut self,
+        entity: Entity,
+    ) -> Option<RefMut<Exclusive, T>> {
+        // safe because the &mut self ensures exclusivity
+        unsafe { self.get_component_mut_unchecked(entity) }
     }
+
+    /// Gets tag data for the given entity.
+    ///
+    /// Returns `Some(data)` if the entity was found and contains the specified data.
+    /// Otherwise `None` is returned.
+    #[inline]
+    pub fn get_tag<T: Tag>(&self, entity: Entity) -> Option<&T> {
+        unsafe { (*self.world).get_tag(entity) }
+    }
+
+    /// Determines if the given `Entity` is alive within this `World`.
+    #[inline]
+    pub fn is_alive(&self, entity: Entity) -> bool { unsafe { (*self.world).is_alive(entity) } }
 }
 
 /// The concrete type which contains the system closure provided by the user.  This struct should
@@ -351,13 +598,13 @@ where
     resources: R,
     queries: AtomicRefCell<Q>,
     run_fn: AtomicRefCell<F>,
-    archetypes: BitSet,
+    archetypes: ArchetypeAccess,
 
     // These are stored statically instead of always iterated and created from the
     // query types, which would make allocations every single request
     access: SystemAccess,
 
-    // We pre-allocate a commnad buffer for ourself. Writes are self-draining so we never have to rellocate.
+    // We pre-allocate a command buffer for ourself. Writes are self-draining so we never have to rellocate.
     command_buffer: AtomicRefCell<CommandBuffer>,
 }
 
@@ -380,12 +627,12 @@ where
     }
 
     fn prepare(&mut self, world: &World) {
-        self.queries
-            .get_mut()
-            .filter_archetypes(world, &mut self.archetypes);
+        if let ArchetypeAccess::Some(bitset) = &mut self.archetypes {
+            self.queries.get_mut().filter_archetypes(world, bitset);
+        }
     }
 
-    fn accesses_archetypes(&self) -> &BitSet { &self.archetypes }
+    fn accesses_archetypes(&self) -> &ArchetypeAccess { &self.archetypes }
 
     fn command_buffer_mut(&self) -> RefMut<Exclusive, CommandBuffer> {
         self.command_buffer.get_mut()
@@ -394,8 +641,9 @@ where
     fn run(&self, world: &World) {
         let mut resources = R::fetch(&world.resources);
         let mut queries = self.queries.get_mut();
-        let mut prepared_queries = unsafe { queries.prepare(world) };
-        let mut world_shim = unsafe { PreparedWorld::new(world, &self.access.components) };
+        let mut prepared_queries = unsafe { queries.prepare() };
+        let mut world_shim =
+            unsafe { PreparedWorld::new(world, &self.access.components, &self.archetypes) };
 
         // Give the command buffer a new entity block.
         // This should usually just pull a free block, or allocate a new one...
@@ -549,11 +797,11 @@ where
 ///            .read_resource::<TestResource>()
 ///            .with_query(<(Read<Position>, Tagged<Model>)>::query()
 ///                         .filter(!tag::<Static>() | changed::<Position>()))
-///            .build(move |commands, prepared_world, resource, queries| {
+///            .build(move |commands, world, resource, queries| {
 ///                log::trace!("Hello world");
 ///               let mut count = 0;
 ///                {
-///                    for (entity, pos) in queries.iter_entities() {
+///                    for (entity, pos) in queries.iter_entities(&mut *world) {
 ///
 ///                    }
 ///                }
@@ -567,6 +815,7 @@ pub struct SystemBuilder<Q = (), R = ()> {
 
     resource_access: Access<ResourceTypeId>,
     component_access: Access<ComponentTypeId>,
+    access_all_archetypes: bool,
 }
 
 impl<Q, R> SystemBuilder<Q, R>
@@ -586,6 +835,7 @@ where
             resources: (),
             resource_access: Access::default(),
             component_access: Access::default(),
+            access_all_archetypes: false,
         }
     }
 
@@ -608,11 +858,11 @@ where
 
         SystemBuilder {
             name: self.name,
-
             queries: ConsAppend::append(self.queries, query),
             resources: self.resources,
             resource_access: self.resource_access,
             component_access: self.component_access,
+            access_all_archetypes: self.access_all_archetypes,
         }
     }
 
@@ -629,12 +879,12 @@ where
         self.resource_access.reads.push(ResourceTypeId::of::<T>());
 
         SystemBuilder {
-            resources: ConsAppend::append(self.resources, Read::<T>::default()),
             name: self.name,
-
             queries: self.queries,
+            resources: ConsAppend::append(self.resources, Read::<T>::default()),
             resource_access: self.resource_access,
             component_access: self.component_access,
+            access_all_archetypes: self.access_all_archetypes,
         }
     }
 
@@ -651,12 +901,12 @@ where
         self.resource_access.writes.push(ResourceTypeId::of::<T>());
 
         SystemBuilder {
-            resources: ConsAppend::append(self.resources, Write::<T>::default()),
             name: self.name,
-
             queries: self.queries,
+            resources: ConsAppend::append(self.resources, Write::<T>::default()),
             resource_access: self.resource_access,
             component_access: self.component_access,
+            access_all_archetypes: self.access_all_archetypes,
         }
     }
 
@@ -675,6 +925,7 @@ where
         T: Component,
     {
         self.component_access.reads.push(ComponentTypeId::of::<T>());
+        self.access_all_archetypes = true;
 
         self
     }
@@ -696,6 +947,7 @@ where
         self.component_access
             .writes
             .push(ComponentTypeId::of::<T>());
+        self.access_all_archetypes = true;
 
         self
     }
@@ -716,7 +968,11 @@ where
             run_fn: AtomicRefCell::new(disposable),
             resources: self.resources.flatten(),
             queries: AtomicRefCell::new(self.queries.flatten()),
-            archetypes: BitSet::default(), //TODO:
+            archetypes: if self.access_all_archetypes {
+                ArchetypeAccess::All
+            } else {
+                ArchetypeAccess::Some(BitSet::default())
+            },
             access: SystemAccess {
                 resources: self.resource_access,
                 components: self.component_access,
@@ -759,10 +1015,10 @@ where
         ))
     }
 
-    /// Builds a standard legion `System`. a system is considered a closure for all purposes. This
+    /// Builds a standard legion `System`. A system is considered a closure for all purposes. This
     /// closure is `FnMut`, allowing for capture of variables for tracking state for this system.
     /// Instead of the classic OOP architecture of a system, this lets you still maintain state
-    /// across execution of the systems while leveraging the type simantics of closures for better
+    /// across execution of the systems while leveraging the type semantics of closures for better
     /// ergonomics.
     pub fn build<F>(self, run_fn: F) -> Box<dyn Schedulable>
     where
@@ -781,9 +1037,9 @@ where
     }
 
     /// Builds a system which is not `Schedulable`, as it is not thread safe (!Send and !Sync),
-    /// but still implements all the calling infastructure of the `Runnable` trait. This provides
+    /// but still implements all the calling infrastructure of the `Runnable` trait. This provides
     /// a way for legion consumers to leverage the `System` construction and type-handling of
-    /// this build for thread local systems which cannot leave the main initializating thread.
+    /// this build for thread local systems which cannot leave the main initializing thread.
     pub fn build_thread_local<F>(self, run_fn: F) -> Box<dyn Runnable>
     where
         <R as ConsFlatten>::Output: ResourceSet + Send + Sync,
@@ -801,7 +1057,11 @@ where
             run_fn: AtomicRefCell::new(disposable),
             resources: self.resources.flatten(),
             queries: AtomicRefCell::new(self.queries.flatten()),
-            archetypes: BitSet::default(), //TODO:
+            archetypes: if self.access_all_archetypes {
+                ArchetypeAccess::All
+            } else {
+                ArchetypeAccess::Some(BitSet::default())
+            },
             access: SystemAccess {
                 resources: self.resource_access,
                 components: self.component_access,
@@ -849,7 +1109,11 @@ where
             run_fn: AtomicRefCell::new(disposable),
             resources: self.resources.flatten(),
             queries: AtomicRefCell::new(self.queries.flatten()),
-            archetypes: BitSet::default(), //TODO:
+            archetypes: if self.access_all_archetypes {
+                ArchetypeAccess::All
+            } else {
+                ArchetypeAccess::Some(BitSet::default())
+            },
             access: SystemAccess {
                 resources: self.resource_access,
                 components: self.component_access,
@@ -1022,11 +1286,11 @@ mod tests {
             .read_resource::<TestResource>()
             .with_query(Read::<Pos>::query())
             .with_query(Read::<Vel>::query())
-            .build(move |_commands, _world, resource, queries| {
+            .build(move |_commands, world, resource, queries| {
                 assert_eq!(resource.0, 123);
                 let mut count = 0;
                 {
-                    for (entity, pos) in queries.0.iter_entities() {
+                    for (entity, pos) in queries.0.iter_entities(world) {
                         assert_eq!(expected.get(&entity).unwrap().0, *pos);
                         count += 1;
                     }
@@ -1195,6 +1459,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "par-iter")]
+    #[allow(clippy::float_cmp)]
     fn par_comp_readwrite() {
         let _ = env_logger::builder().is_test(true).try_init();
 
@@ -1221,8 +1486,8 @@ mod tests {
 
         let system1 = SystemBuilder::<()>::new("TestSystem1")
             .with_query(<(Read<Comp1>, Read<Comp2>)>::query())
-            .build(move |_, _, _, query| {
-                query.iter().for_each(|(one, two)| {
+            .build(move |_, world, _, query| {
+                query.iter(world).for_each(|(one, two)| {
                     assert_eq!(one.0, 69.);
                     assert_eq!(one.1, 69.);
                     assert_eq!(one.2, 69.);
@@ -1235,8 +1500,8 @@ mod tests {
 
         let system2 = SystemBuilder::<()>::new("TestSystem2")
             .with_query(<(Write<Comp1>, Read<Comp2>)>::query())
-            .build(move |_, _, _, query| {
-                query.iter().for_each(|(mut one, two)| {
+            .build(move |_, world, _, query| {
+                query.iter(world).for_each(|(mut one, two)| {
                     one.0 = 456.;
                     one.1 = 456.;
                     one.2 = 456.;
@@ -1249,8 +1514,8 @@ mod tests {
 
         let system3 = SystemBuilder::<()>::new("TestSystem3")
             .with_query(<(Write<Comp1>, Write<Comp2>)>::query())
-            .build(move |_, _, _, query| {
-                query.iter().for_each(|(mut one, two)| {
+            .build(move |_, world, _, query| {
+                query.iter(world).for_each(|(mut one, two)| {
                     assert_eq!(one.0, 456.);
                     assert_eq!(one.1, 456.);
                     assert_eq!(one.2, 456.);
@@ -1271,8 +1536,8 @@ mod tests {
 
         let system4 = SystemBuilder::<()>::new("TestSystem4")
             .with_query(<(Read<Comp1>, Read<Comp2>)>::query())
-            .build(move |_, _, _, query| {
-                query.iter().for_each(|(one, two)| {
+            .build(move |_, world, _, query| {
+                query.iter(world).for_each(|(one, two)| {
                     assert_eq!(one.0, 789.);
                     assert_eq!(one.1, 789.);
                     assert_eq!(one.2, 789.);
@@ -1285,8 +1550,8 @@ mod tests {
 
         let system5 = SystemBuilder::<()>::new("TestSystem5")
             .with_query(<(Write<Comp1>, Write<Comp2>)>::query())
-            .build(move |_, _, _, query| {
-                query.iter().for_each(|(mut one, mut two)| {
+            .build(move |_, world, _, query| {
+                query.iter(world).for_each(|(mut one, mut two)| {
                     assert_eq!(one.0, 789.);
                     assert_eq!(one.1, 789.);
                     assert_eq!(one.2, 789.);

--- a/src/world.rs
+++ b/src/world.rs
@@ -41,6 +41,7 @@ use rayon::prelude::*;
 
 #[cfg(feature = "events")]
 use crate::event::{Channel, EntityEvent, WorldCreatedEvent};
+use crate::accessor::{EntityAccessor, EntityAccessorMut};
 
 /// The `Universe` is a factory for creating `World`s.
 ///
@@ -495,6 +496,31 @@ impl World {
             // move the entity into a suitable chunk
             self.move_entity(entity, &[], &[], &[], &[TagTypeId::of::<T>()]);
         }
+    }
+
+    /// Returns an immutable accessor to components for `entity`.
+    ///
+    /// If the entity is dead, returns `None`.
+    pub fn get_accessor(&self, entity: Entity) -> Option<EntityAccessor> {
+        EntityAccessor::new(self, entity)
+    }
+
+    /// Returns a mutable accessor to components for `entity`.
+    ///
+    /// If the entity is dead, returns `None`.
+    pub fn get_accessor_mut(&mut self, entity: Entity) -> Option<EntityAccessorMut> {
+        // safe because the &mut self ensures exclusivity
+        unsafe { EntityAccessorMut::new(self, entity) }
+    }
+
+    /// Returns a mutable accessor to components for `entity`.
+    ///
+    /// If the entity is dead, returns `None`.
+    ///
+    /// # Safety
+    /// Accessing a component which is already being concurrently accessed elsewhere is undefined behavior.
+    pub unsafe fn get_accessor_mut_unchecked(&self, entity: Entity) -> Option<EntityAccessorMut> {
+        EntityAccessorMut::new(self, entity)
     }
 
     /// Borrows component data for the given entity.

--- a/tests/query_api.rs
+++ b/tests/query_api.rs
@@ -117,7 +117,7 @@ fn query_read_entity_data() {
     let mut query = Read::<Pos>::query();
 
     let mut count = 0;
-    for (entity, pos) in query.iter_entities(&world) {
+    for (entity, pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         count += 1;
     }
@@ -149,7 +149,7 @@ fn query_cached_read_entity_data() {
     let mut query = Read::<Pos>::query(); //.cached();
 
     let mut count = 0;
-    for (entity, pos) in query.iter_entities(&world) {
+    for (entity, pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         count += 1;
     }
@@ -181,7 +181,7 @@ fn query_read_entity_data_par() {
 
     let count = AtomicUsize::new(0);
     let mut query = Read::<Pos>::query();
-    query.par_for_each_chunk(&world, |mut chunk| {
+    query.par_for_each_chunk(&mut world, |mut chunk| {
         for (entity, pos) in chunk.iter_entities() {
             assert_eq!(expected.get(&entity).unwrap().0, *pos);
             count.fetch_add(1, Ordering::SeqCst);
@@ -215,7 +215,7 @@ fn query_read_entity_data_par_foreach() {
 
     let count = AtomicUsize::new(0);
     let mut query = Read::<Pos>::query();
-    query.par_for_each(&world, |_pos| {
+    query.par_for_each(&mut world, |_pos| {
         count.fetch_add(1, Ordering::SeqCst);
     });
 
@@ -246,7 +246,7 @@ fn query_read_entity_data_tuple() {
     let mut query = <(Read<Pos>, Read<Rot>)>::query();
 
     let mut count = 0;
-    for (entity, (pos, rot)) in query.iter_entities(&world) {
+    for (entity, (pos, rot)) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         assert_eq!(expected.get(&entity).unwrap().1, *rot);
         count += 1;
@@ -279,7 +279,7 @@ fn query_write_entity_data() {
     let mut query = Write::<Pos>::query();
 
     let mut count = 0;
-    for (entity, mut pos) in query.iter_entities(&world) {
+    for (entity, mut pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         count += 1;
 
@@ -313,7 +313,7 @@ fn query_write_entity_data_tuple() {
     let mut query = <(Write<Pos>, Write<Rot>)>::query();
 
     let mut count = 0;
-    for (entity, (mut pos, mut rot)) in query.iter_entities(&world) {
+    for (entity, (mut pos, mut rot)) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         assert_eq!(expected.get(&entity).unwrap().1, *rot);
         count += 1;
@@ -349,7 +349,7 @@ fn query_mixed_entity_data_tuple() {
     let mut query = <(Read<Pos>, Write<Rot>)>::query();
 
     let mut count = 0;
-    for (entity, (pos, mut rot)) in query.iter_entities(&world) {
+    for (entity, (pos, mut rot)) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         assert_eq!(expected.get(&entity).unwrap().1, *rot);
         count += 1;
@@ -384,7 +384,7 @@ fn query_partial_match() {
     let mut query = <(Read<Pos>, Write<Rot>)>::query();
 
     let mut count = 0;
-    for (entity, (pos, mut rot)) in query.iter_entities(&world) {
+    for (entity, (pos, mut rot)) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         assert_eq!(expected.get(&entity).unwrap().1, *rot);
         count += 1;
@@ -413,7 +413,7 @@ fn query_read_shared_data() {
     let mut query = Tagged::<Static>::query();
 
     let mut count = 0;
-    for marker in query.iter(&world) {
+    for marker in query.iter(&mut world) {
         assert_eq!(Static, *marker);
         count += 1;
     }
@@ -445,7 +445,7 @@ fn query_on_changed_first() {
     let mut query = Read::<Pos>::query().filter(changed::<Pos>() | changed::<Rot>());
 
     let mut count = 0;
-    for (entity, pos) in query.iter_entities(&world) {
+    for (entity, pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         count += 1;
     }
@@ -477,7 +477,7 @@ fn query_on_changed_no_changes() {
     let mut query = Read::<Pos>::query().filter(changed::<Pos>());
 
     let mut count = 0;
-    for (entity, pos) in query.iter_entities(&world) {
+    for (entity, pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         count += 1;
     }
@@ -485,7 +485,7 @@ fn query_on_changed_no_changes() {
     assert_eq!(components.len(), count);
 
     count = 0;
-    for (entity, pos) in query.iter_entities(&world) {
+    for (entity, pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         count += 1;
     }
@@ -517,7 +517,7 @@ fn query_on_changed_self_changes() {
     let mut query = Write::<Pos>::query().filter(changed::<Pos>());
 
     let mut count = 0;
-    for (entity, mut pos) in query.iter_entities(&world) {
+    for (entity, mut pos) in query.iter_entities(&mut world) {
         assert_eq!(expected.get(&entity).unwrap().0, *pos);
         *pos = Pos(1., 1., 1.);
         count += 1;
@@ -526,7 +526,7 @@ fn query_on_changed_self_changes() {
     assert_eq!(components.len(), count);
 
     count = 0;
-    for pos in query.iter(&world) {
+    for pos in query.iter(&mut world) {
         assert_eq!(Pos(1., 1., 1.), *pos);
         count += 1;
     }

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -260,13 +260,13 @@ fn mutate_add_component() {
     let mut query_without_scale = <(Read<Pos>, Read<Rot>)>::query();
     let mut query_with_scale = <(Read<Pos>, Read<Rot>, Read<Scale>)>::query();
 
-    assert_eq!(3, query_without_scale.iter(&world).count());
-    assert_eq!(0, query_with_scale.iter(&world).count());
+    assert_eq!(3, query_without_scale.iter(&mut world).count());
+    assert_eq!(0, query_with_scale.iter(&mut world).count());
 
     world.add_component(*entities.get(1).unwrap(), Scale(0.5, 0.5, 0.5));
 
-    assert_eq!(3, query_without_scale.iter(&world).count());
-    assert_eq!(1, query_with_scale.iter(&world).count());
+    assert_eq!(3, query_without_scale.iter(&mut world).count());
+    assert_eq!(1, query_with_scale.iter(&mut world).count());
 }
 
 #[test]
@@ -288,13 +288,13 @@ fn mutate_remove_component() {
     let mut query_without_rot = Read::<Pos>::query().filter(!component::<Rot>());
     let mut query_with_rot = <(Read<Pos>, Read<Rot>)>::query();
 
-    assert_eq!(0, query_without_rot.iter(&world).count());
-    assert_eq!(3, query_with_rot.iter(&world).count());
+    assert_eq!(0, query_without_rot.iter(&mut world).count());
+    assert_eq!(3, query_with_rot.iter(&mut world).count());
 
     world.remove_component::<Rot>(*entities.get(1).unwrap());
 
-    assert_eq!(1, query_without_rot.iter(&world).count());
-    assert_eq!(2, query_with_rot.iter(&world).count());
+    assert_eq!(1, query_without_rot.iter(&mut world).count());
+    assert_eq!(2, query_with_rot.iter(&mut world).count());
 }
 
 #[test]
@@ -316,13 +316,13 @@ fn mutate_add_tag() {
     let mut query_without_static = <(Read<Pos>, Read<Rot>)>::query();
     let mut query_with_static = <(Read<Pos>, Read<Rot>, Tagged<Static>)>::query();
 
-    assert_eq!(3, query_without_static.iter(&world).count());
-    assert_eq!(0, query_with_static.iter(&world).count());
+    assert_eq!(3, query_without_static.iter(&mut world).count());
+    assert_eq!(0, query_with_static.iter(&mut world).count());
 
     world.add_tag(*entities.get(1).unwrap(), Static);
 
-    assert_eq!(3, query_without_static.iter(&world).count());
-    assert_eq!(1, query_with_static.iter(&world).count());
+    assert_eq!(3, query_without_static.iter(&mut world).count());
+    assert_eq!(1, query_with_static.iter(&mut world).count());
 }
 
 #[test]
@@ -344,13 +344,13 @@ fn mutate_remove_tag() {
     let mut query_without_static = <(Read<Pos>, Read<Rot>)>::query().filter(!tag::<Static>());
     let mut query_with_static = <(Read<Pos>, Read<Rot>, Tagged<Static>)>::query();
 
-    assert_eq!(0, query_without_static.iter(&world).count());
-    assert_eq!(3, query_with_static.iter(&world).count());
+    assert_eq!(0, query_without_static.iter(&mut world).count());
+    assert_eq!(3, query_with_static.iter(&mut world).count());
 
     world.remove_tag::<Static>(*entities.get(1).unwrap());
 
-    assert_eq!(1, query_without_static.iter(&world).count());
-    assert_eq!(2, query_with_static.iter(&world).count());
+    assert_eq!(1, query_without_static.iter(&mut world).count());
+    assert_eq!(2, query_with_static.iter(&mut world).count());
 }
 
 #[test]
@@ -391,8 +391,8 @@ fn mutate_change_tag() {
     let mut query_model_3 = <(Read<Pos>, Read<Rot>)>::query().filter(tag_value(&Model(3)));
     let mut query_model_5 = <(Read<Pos>, Read<Rot>)>::query().filter(tag_value(&Model(5)));
 
-    assert_eq!(3, query_model_5.iter(&world).count());
-    assert_eq!(0, query_model_3.iter(&world).count());
+    assert_eq!(3, query_model_5.iter(&mut world).count());
+    assert_eq!(0, query_model_3.iter(&mut world).count());
 
     log::trace!("STARTING CHANGE");
     world.add_tag(*entities.get(1).unwrap(), Model(3));
@@ -401,7 +401,7 @@ fn mutate_change_tag() {
     assert_eq!(
         1,
         query_model_3
-            .iter_entities(&world)
+            .iter_entities(&mut world)
             .map(|e| {
                 log::trace!("iter: {:?}", e);
                 e
@@ -413,5 +413,5 @@ fn mutate_change_tag() {
         Model(3)
     );
 
-    assert_eq!(2, query_model_5.iter(&world).count());
+    assert_eq!(2, query_model_5.iter(&mut world).count());
 }


### PR DESCRIPTION
Adds random access APIs for `Query` and extends random access support using a new `EntityAccessor` type.

- [x] New `EntityAccessor` and `EntityAccessorMut` APIs, which can be created using `World::get_accessor()` or `Query::find_accessor()`, allow accessing arbitrary components of an entity. This can be useful for passing an entity and its components to a function without needing access to the `World`.
- [ ] `Query::find()` attempts to find component data within a query space for a given entity.
```rust
let (mut position, velocity) = <(Write<Position>, Read<Velocity>)>::query()
    .find(entity, &mut world)
    .expect("entity not within query space");
```

Resolves #19.

Note that this depends on the merging of #27.