### PR TITLE
Add archetype creation events

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -8,6 +8,7 @@ use rayon::prelude::*;
 
 #[cfg(feature = "par-iter")]
 use crossbeam::queue::{ArrayQueue, PopError, PushError};
+use crate::storage::ArchetypeId;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ListenerId(usize);
@@ -139,6 +140,12 @@ pub struct WorldCreatedEvent(pub WorldId);
 pub enum ComponentEvent {
     ComponentAdded,
     ComponentRemoved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArchetypeEvent {
+    /// Indicates that an archetype was created.
+    Created(ArchetypeId),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This allows users to be notified when a new archetype is created.

I require this for my custom system scheduler implementation in order to optimize stage execution, and I imagine it could also be utilized in Legion's own scheduler as an optimization.