### PR TITLE
Fix change filter on optional components

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1060,8 +1060,12 @@ impl<'a, T: Component> Filter<ChunkFilterData<'a>> for ComponentChangedFilter<T>
 
     #[inline]
     fn is_match(&self, item: &<Self::Iter as Iterator>::Item) -> Option<bool> {
-        let components = item.components(ComponentTypeId::of::<T>()).unwrap();
-        let version = components.version();
+        let components = item.components(ComponentTypeId::of::<T>());
+        if components.is_none() {
+            return Some(false);
+        }
+
+        let version = components.unwrap().version();
         let mut last_read = self.last_read_version.load(Ordering::Relaxed);
         if last_read < version {
             loop {

--- a/tests/query_api.rs
+++ b/tests/query_api.rs
@@ -502,7 +502,7 @@ fn query_on_changed_self_changes() {
 
 #[test]
 fn query_try_with_changed_filter() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt::try_init();
 
     #[derive(Clone, Copy, Debug, PartialEq)]
     struct Sum(f32);

--- a/tests/query_api.rs
+++ b/tests/query_api.rs
@@ -573,3 +573,68 @@ fn query_on_changed_self_changes() {
 
     assert_eq!(components.len(), count);
 }
+
+#[test]
+fn query_try_with_changed_filter() {
+    let _ = env_logger::builder().is_test(true).try_init();
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct Sum(f32);
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct A(f32);
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct B(f32);
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    let sum_entity = world.insert((), Some((Sum(0.),)))[0];
+    let a_entity = world.insert((), Some((Sum(0.), A(1.))))[0];
+    let b_entity = world.insert((), Some((Sum(0.), B(2.))))[0];
+    let a_b_entity = world.insert((), Some((Sum(0.), A(1.), B(2.))))[0];
+
+    let mut query =
+        <(Write<Sum>, TryRead<A>, TryRead<B>)>::query().filter(changed::<A>() | changed::<B>());
+
+    let mut count = 0;
+    for (mut sum, a, b) in query.iter(&mut world) {
+        sum.0 = a.map_or(0., |x| x.0) + b.map_or(0., |x| x.0);
+        count += 1;
+    }
+    assert_eq!(3, count);
+    assert_eq!(
+        world.get_component::<Sum>(sum_entity).map(|x| *x),
+        Some(Sum(0.))
+    );
+    assert_eq!(
+        world.get_component::<Sum>(a_entity).map(|x| *x),
+        Some(Sum(1.))
+    );
+    assert_eq!(
+        world.get_component::<Sum>(b_entity).map(|x| *x),
+        Some(Sum(2.))
+    );
+    assert_eq!(
+        world.get_component::<Sum>(a_b_entity).map(|x| *x),
+        Some(Sum(3.))
+    );
+
+    count = 0;
+    for (mut sum, a, b) in query.iter(&mut world) {
+        sum.0 = a.map_or(0., |x| x.0) + b.map_or(0., |x| x.0);
+        count += 1;
+    }
+    assert_eq!(0, count);
+
+    *world.get_component_mut::<B>(a_b_entity).unwrap() = B(3.0);
+    count = 0;
+    for (mut sum, a, b) in query.iter(&mut world) {
+        sum.0 = a.map_or(0., |x| x.0) + b.map_or(0., |x| x.0);
+        count += 1;
+    }
+    assert_eq!(1, count);
+    assert_eq!(
+        world.get_component::<Sum>(a_b_entity).map(|x| *x),
+        Some(Sum(4.))
+    );
+}


### PR DESCRIPTION
With the new optional components queries (`TryRead` and `TryWrite`) it will be useful to refer to this optional components while filtering by change. For now situation when optional component is missing on entity, but present in the filter results in panic. Not quite sure with the actual implementation though.