### PR TITLE
Fix incorrect Chunk iterator on tags during iter_chunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   check:

--- a/src/query.rs
+++ b/src/query.rs
@@ -436,7 +436,7 @@ impl<'a, V: for<'b> View<'b>> Chunk<'a, V> {
                     .get_unchecked(index)
             },
             archetype,
-            index,
+            index: set,
             view: PhantomData,
         }
     }

--- a/tests/query_api.rs
+++ b/tests/query_api.rs
@@ -499,3 +499,24 @@ fn query_on_changed_self_changes() {
 
     assert_eq!(components.len(), count);
 }
+
+#[test]
+fn query_iter_chunks_tag() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    world.insert((Static, Model(0)), vec![()]);
+    world.insert((Static, Model(1)), vec![()]);
+    world.insert((Static, Model(2)), vec![()]);
+
+    let mut query = <(Tagged<Static>, Tagged<Model>)>::query();
+
+    for chunk in query.iter_chunks_immutable(&world) {
+        let model = chunk.tag::<Model>().cloned();
+        for entity in chunk.entities() {
+            assert_eq!(world.get_tag::<Model>(*entity), model.as_ref());
+        }
+    }
+}


### PR DESCRIPTION
- Remove extra dead comment
- Fixed `Chunk` pulling from the wrong chunk index. It was querying as chunk_index when it should have been set index