### PR TITLE
Include only needed crossbeam dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "TomGillen/legion", branch = "master" }
 [features]
 default = ["par-iter", "par-schedule", "events", "ffi"]
 par-iter = ["rayon"]
-par-schedule = ["rayon"]
+par-schedule = ["rayon", "crossbeam-queue"]
 log = ["tracing/log", "tracing/log-always"]
 ffi = []
 events = ["rayon"]
@@ -26,7 +26,8 @@ parking_lot = "0.9"
 downcast-rs = "1.0"
 itertools = "0.8"
 rayon = { version = "1.2", optional = true }
-crossbeam = { version = "0.7" }
+crossbeam-queue = { version = "0.2.0", optional = true }
+crossbeam-channel = "0.4.0"
 derivative = "1"
 smallvec = "0.6"
 bit-set = "0.5"

--- a/src/command.rs
+++ b/src/command.rs
@@ -11,7 +11,7 @@ use derivative::Derivative;
 use std::{marker::PhantomData, sync::Arc};
 
 #[cfg(feature = "par-schedule")]
-use crossbeam::queue::SegQueue;
+use crossbeam_queue::SegQueue;
 
 #[cfg(not(feature = "par-schedule"))]
 use crate::borrow::{AtomicRefCell, RefMut};

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,7 +4,7 @@ use crate::filter::{
 };
 use crate::storage::ArchetypeId;
 use crate::storage::ChunkId;
-use crossbeam::channel::{Sender, TrySendError};
+use crossbeam_channel::{Sender, TrySendError};
 use std::sync::Arc;
 
 /// Events emitted by a world to subscribers. See `World.subscribe(Sender, EntityFilter)`.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -188,7 +188,7 @@ impl Storage {
 
     pub(crate) fn subscribe<T: EntityFilter + Sync + 'static>(
         &mut self,
-        sender: crossbeam::channel::Sender<Event>,
+        sender: crossbeam_channel::Sender<Event>,
         filter: T,
     ) {
         let subscriber = Subscriber::new(Arc::new(EventFilterWrapper(filter.clone())), sender);

--- a/src/world.rs
+++ b/src/world.rs
@@ -130,7 +130,7 @@ impl World {
     /// # struct Model;
     /// # let universe = Universe::new();
     /// # let mut world = universe.create_world();
-    /// let (sender, receiver) = crossbeam::channel::unbounded();
+    /// let (sender, receiver) = crossbeam_channel::unbounded();
     /// world.subscribe(sender, component::<Position>() | tag::<Model>());
     ///
     /// for event in receiver.try_iter() {
@@ -139,7 +139,7 @@ impl World {
     /// ```
     pub fn subscribe<T: EntityFilter + Sync + 'static>(
         &mut self,
-        sender: crossbeam::channel::Sender<Event>,
+        sender: crossbeam_channel::Sender<Event>,
         filter: T,
     ) {
         self.storage_mut().subscribe(sender, filter);


### PR DESCRIPTION
When building without `par-schedule` feature one only needs the crossbeam-channel crate, not all the other parts of crossbeam. 

This reduces compile times when building with few features. We ran into this because we are building with `default-features = false` and wanted to reduce amount of dependencies and improve build times.

And when building with that feature, we only additionally need crossbeam-queue. Although in practice in that case one gets rest of crossbeam due to rayon.