### PR TITLE
Remove SegQueue from CommandBuffer & Additional Tests

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -216,7 +216,6 @@ impl CommandBuffer {
                 EntityCommand::ExecWorld(closure) => closure(world),
             }
         }
-
     }
 
     pub fn build_entity(&mut self) -> Result<EntityBuilder<(), ()>, CommandError> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,10 +10,6 @@ use bit_set::BitSet;
 use derivative::Derivative;
 use std::{marker::PhantomData, sync::Arc};
 
-#[cfg(feature = "par-schedule")]
-use crossbeam_queue::SegQueue;
-
-#[cfg(not(feature = "par-schedule"))]
 use crate::borrow::{AtomicRefCell, RefMut};
 
 pub trait WorldWritable {
@@ -193,9 +189,6 @@ where
 
 #[derive(Default)]
 pub struct CommandBuffer {
-    #[cfg(feature = "par-schedule")]
-    commands: SegQueue<EntityCommand>,
-    #[cfg(not(feature = "par-schedule"))]
     commands: AtomicRefCell<Vec<EntityCommand>>,
     block: Option<EntityBlock>,
     used_entities: BitSet,
@@ -210,37 +203,20 @@ pub enum CommandError {
 }
 
 impl CommandBuffer {
-    #[cfg(not(feature = "par-schedule"))]
     #[inline]
     fn get_commands(&self) -> RefMut<Vec<EntityCommand>> { self.commands.get_mut() }
 
-    #[cfg(feature = "par-schedule")]
-    #[inline]
-    fn get_commands(&self) -> &SegQueue<EntityCommand> { &self.commands }
-
     pub fn write(&self, world: &mut World) {
         tracing::trace!("Draining command buffer");
-        #[cfg(feature = "par-schedule")]
-        {
-            while let Ok(command) = self.get_commands().pop() {
-                match command {
-                    EntityCommand::WriteWorld(ptr) => ptr.write(world),
-                    EntityCommand::ExecMutWorld(closure) => closure(world),
-                    EntityCommand::ExecWorld(closure) => closure(world),
-                }
+
+        while let Some(command) = self.get_commands().pop() {
+            match command {
+                EntityCommand::WriteWorld(ptr) => ptr.write(world),
+                EntityCommand::ExecMutWorld(closure) => closure(world),
+                EntityCommand::ExecWorld(closure) => closure(world),
             }
         }
 
-        #[cfg(not(feature = "par-schedule"))]
-        {
-            while let Some(command) = self.get_commands().pop() {
-                match command {
-                    EntityCommand::WriteWorld(ptr) => ptr.write(world),
-                    EntityCommand::ExecMutWorld(closure) => closure(world),
-                    EntityCommand::ExecWorld(closure) => closure(world),
-                }
-            }
-        }
     }
 
     pub fn build_entity(&mut self) -> Result<EntityBuilder<(), ()>, CommandError> {

--- a/src/system.rs
+++ b/src/system.rs
@@ -1395,7 +1395,7 @@ mod tests {
 
         let expected_copy = expected.clone();
         let mut system = SystemBuilder::<()>::new("TestSystem")
-            .with_query(<(Read::<Pos>, Read<Vel>)>::query())
+            .with_query(<(Read<Pos>, Read<Vel>)>::query())
             .build(move |_, world, _, query| {
                 let mut count = 0;
                 {
@@ -1428,7 +1428,9 @@ mod tests {
         #[derive(Default, Clone, Copy)]
         pub struct Balls(u32);
 
-        let components = (0..30000).map(|_|  (Pos(1., 2., 3.), Vel(0.1, 0.2, 0.3))).collect::<Vec<_>>();
+        let components = (0..30000)
+            .map(|_| (Pos(1., 2., 3.), Vel(0.1, 0.2, 0.3)))
+            .collect::<Vec<_>>();
 
         let mut expected = HashMap::<Entity, (Pos, Vel)>::new();
 
@@ -1438,10 +1440,9 @@ mod tests {
             }
         }
 
-
         let expected_copy = expected.clone();
         let mut system = SystemBuilder::<()>::new("TestSystem")
-            .with_query(<(Read::<Pos>, Read<Vel>)>::query())
+            .with_query(<(Read<Pos>, Read<Vel>)>::query())
             .build(move |command_buffer, world, _, query| {
                 let mut count = 0;
                 {
@@ -1465,7 +1466,6 @@ mod tests {
         system.prepare(&world);
         system.run(&world);
     }
-
 
     #[test]
     #[cfg(feature = "par-schedule")]
@@ -1725,4 +1725,3 @@ mod tests {
         });
     }
 }
-

--- a/src/system.rs
+++ b/src/system.rs
@@ -1371,6 +1371,103 @@ mod tests {
     }
 
     #[test]
+    fn system_mutate_archetype() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let universe = Universe::new();
+        let mut world = universe.create_world();
+
+        #[derive(Default, Clone, Copy)]
+        pub struct Balls(u32);
+
+        let components = vec![
+            (Pos(1., 2., 3.), Vel(0.1, 0.2, 0.3)),
+            (Pos(4., 5., 6.), Vel(0.4, 0.5, 0.6)),
+        ];
+
+        let mut expected = HashMap::<Entity, (Pos, Vel)>::new();
+
+        for (i, e) in world.insert((), components.clone()).iter().enumerate() {
+            if let Some((pos, rot)) = components.get(i) {
+                expected.insert(*e, (*pos, *rot));
+            }
+        }
+
+        let expected_copy = expected.clone();
+        let mut system = SystemBuilder::<()>::new("TestSystem")
+            .with_query(<(Read::<Pos>, Read<Vel>)>::query())
+            .build(move |_, world, _, query| {
+                let mut count = 0;
+                {
+                    for (entity, (pos, vel)) in query.iter_entities_immutable(world) {
+                        assert_eq!(expected_copy.get(&entity).unwrap().0, *pos);
+                        assert_eq!(expected_copy.get(&entity).unwrap().1, *vel);
+                        count += 1;
+                    }
+                }
+
+                assert_eq!(components.len(), count);
+            });
+
+        system.prepare(&world);
+        system.run(&world);
+
+        world.add_component(*(expected.keys().nth(0).unwrap()), Balls::default());
+
+        system.prepare(&world);
+        system.run(&world);
+    }
+
+    #[test]
+    fn system_mutate_archetype_buffer() {
+        let _ = tracing_subscriber::fmt::try_init();
+
+        let universe = Universe::new();
+        let mut world = universe.create_world();
+
+        #[derive(Default, Clone, Copy)]
+        pub struct Balls(u32);
+
+        let components = (0..30000).map(|_|  (Pos(1., 2., 3.), Vel(0.1, 0.2, 0.3))).collect::<Vec<_>>();
+
+        let mut expected = HashMap::<Entity, (Pos, Vel)>::new();
+
+        for (i, e) in world.insert((), components.clone()).iter().enumerate() {
+            if let Some((pos, rot)) = components.get(i) {
+                expected.insert(*e, (*pos, *rot));
+            }
+        }
+
+
+        let expected_copy = expected.clone();
+        let mut system = SystemBuilder::<()>::new("TestSystem")
+            .with_query(<(Read::<Pos>, Read<Vel>)>::query())
+            .build(move |command_buffer, world, _, query| {
+                let mut count = 0;
+                {
+                    for (entity, (pos, vel)) in query.iter_entities_immutable(world) {
+                        assert_eq!(expected_copy.get(&entity).unwrap().0, *pos);
+                        assert_eq!(expected_copy.get(&entity).unwrap().1, *vel);
+                        count += 1;
+
+                        command_buffer.add_component(entity, Balls::default());
+                    }
+                }
+
+                assert_eq!(components.len(), count);
+            });
+
+        system.prepare(&world);
+        system.run(&world);
+
+        system.command_buffer_mut().write(&mut world);
+
+        system.prepare(&world);
+        system.run(&world);
+    }
+
+
+    #[test]
     #[cfg(feature = "par-schedule")]
     fn par_res_write() {
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1628,3 +1725,4 @@ mod tests {
         });
     }
 }
+


### PR DESCRIPTION
This removes SegQueue from CommandBuffer. it was causing out-of-order command buffer operations, leading to panics due to things occuring out of order. This also refs #53, as it removes another crossbeam usage.

This also adds a few tests to world for a bug I was attempting to track.