### PR TITLE
Finish the CommandBuffer implementation

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,0 +1,5 @@
+[book]
+title = "The Legion Book"
+multilingual = false
+author = "Walter Pearce"
+description = "Introduction to Legion ECS"

--- a/docs/book/src/01_introduction.md
+++ b/docs/book/src/01_introduction.md
@@ -1,0 +1,33 @@
+# Introduction
+
+Welcome to the Legion book! This book is intended to be a summary overview of legion, including: 
+- An overview of how to use it
+- Some examples of different use case scenarios
+- how it is different than other Entity-Component-Systems in the rust ecosystem
+- Overviews of some pertinent internals
+
+This book assumes a general understanding of the concepts of the Entity-Component-System design and data composition as a design pattern. More information can be found on the If you need a summary of what an ECS is, please see the [Wikipedia article on ECS].
+
+## Design
+
+Legions internal architecture is heavily inspired by the new Unity ECS architecture [^1], while the publicly facing API is strongly built upon specs [^2], while expanding on it and learning from many of the faults found in that API.
+
+#### Quick Version
+The core concept of Legion design is based around the concept of `Entities`, `Archetypes` and `Chunks`. These three core concepts are the building blocks of legion, and its entity component system.
+
+##### Entities
+Entities are strictly ID's, allocated within a given `Universe` of legion, which allow for uniquely referencing component instances. ID's may be reused generationally, but legion garuntees taht they are unique in any given universe; this is accomplished by providing each `World` in a `Universe` its own Entity Allocator, which will be unique in that universe. 
+
+##### Archetypes
+An archetype is considered a "Grouping of Components and Tags". Entities may have varying numbers and types of components; any combination of these tags and components is considered an `Archetype`. In legion, entity storage and parralelization of system execution are all centered on this concept of Archetypes, or like-entities. 
+ 
+
+
+## Other resources
+
+
+
+[^1]: https://docs.unity3d.com/Packages/com.unity.entities@0.1/manual/ecs_core.html
+[^2]: https://github.com/amethyst/specs
+
+[Wikipedia article on ECS]: https://en.wikipedia.org/wiki/Entity_component_system

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,0 +1,5 @@
+# The Legion Book
+
+- [Introduction](01_introduction.md)
+- [Hello World](02_hello_world.md)
+

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -59,7 +59,7 @@ fn main() {
         .build(|_, mut world, (res1, res2), query| {
             res1.0 = res2.0.clone(); // Write the mutable resource from the immutable resource
 
-            for (mut pos, vel) in query.iter(&mut world) {
+            for (mut pos, vel) in query.iter_mut(&mut world) {
                 pos.0 += vel.0;
                 pos.1 += vel.1;
                 pos.2 += vel.2;
@@ -92,7 +92,7 @@ fn main() {
     let thread_local_example = Box::new(|world: &mut World| {
         // This is an example of a thread local system which has full, exclusive mutable access to the world.
         let query = <(Write<Pos>, Read<Vel>)>::query();
-        for (mut pos, vel) in query.iter(world) {
+        for (mut pos, vel) in query.iter_mut(world) {
             pos.0 += vel.0;
             pos.1 += vel.1;
             pos.2 += vel.2;

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -5,6 +5,11 @@ struct Pos(f32, f32, f32);
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct Vel(f32, f32, f32);
 
+#[derive(Clone)]
+pub struct ExampleResource1(String);
+#[derive(Clone)]
+pub struct ExampleResource2(String);
+
 fn main() {
     let _ = tracing_subscriber::fmt::try_init();
 
@@ -12,18 +17,33 @@ fn main() {
     let universe = Universe::new();
     let mut world = universe.create_world();
 
+    // Insert resources into the world
+    // Resources are also dynamically scheduled just like components, so the accessed
+    // declared within a SystemBuilder is correct.
+    // Any resource accessed by systems *must be* manually inserted beforehand, otherwise it will panic.
+    world
+        .resources
+        .insert(ExampleResource1("ExampleResource1".to_string()));
+    world
+        .resources
+        .insert(ExampleResource2("ExampleResource2".to_string()));
+
     // create entities
-    world.insert(
-        (),
-        vec![
-            (Pos(1., 2., 3.), Vel(1., 2., 3.)),
-            (Pos(1., 2., 3.), Vel(1., 2., 3.)),
-            (Pos(1., 2., 3.), Vel(1., 2., 3.)),
-            (Pos(1., 2., 3.), Vel(1., 2., 3.)),
-        ],
-    );
+    // An insert call is used to insert matching entities into the world.
+    let entities = world
+        .insert(
+            (),
+            vec![
+                (Pos(1., 2., 3.), Vel(1., 2., 3.)),
+                (Pos(1., 2., 3.), Vel(1., 2., 3.)),
+                (Pos(1., 2., 3.), Vel(1., 2., 3.)),
+                (Pos(1., 2., 3.), Vel(1., 2., 3.)),
+            ],
+        )
+        .to_vec();
 
     // update positions
+    // This example shows the use of a `iter`, which is default mutable, across a query.
     let query = <(Write<Pos>, Read<Vel>)>::query();
     for (mut pos, vel) in query.iter(&mut world) {
         pos.0 += vel.0;
@@ -33,8 +53,12 @@ fn main() {
 
     // update positions using a system
     let update_positions = SystemBuilder::new("update_positions")
+        .write_resource::<ExampleResource1>()
+        .read_resource::<ExampleResource2>()
         .with_query(<(Write<Pos>, Read<Vel>)>::query())
-        .build(|_, mut world, _, query| {
+        .build(|_, mut world, (res1, res2), query| {
+            res1.0 = res2.0.clone(); // Write the mutable resource from the immutable resource
+
             for (mut pos, vel) in query.iter(&mut world) {
                 pos.0 += vel.0;
                 pos.1 += vel.1;
@@ -42,6 +66,49 @@ fn main() {
             }
         });
 
-    let mut schedule = Schedule::builder().add_system(update_positions).build();
+    // Uses the command buffer to insert an entity into the world every frame.
+    let entity = entities[0];
+    let command_buffer_usage = SystemBuilder::new("command_buffer_usage")
+        .read_resource::<ExampleResource1>()
+        .write_resource::<ExampleResource2>()
+        // Read and write component definitions allow us to declare access to a component across all archetypes
+        // This means we can use the SubWorld provided to the system as a `World` for that component.
+        .write_component::<Pos>()
+        .build(move |command_buffer, world, (res1, res2), _| {
+            res2.0 = res1.0.clone(); // Write the mutable resource from the immutable resource
+
+            // Read a component from the SubWorld.
+            let _ = world.get_component_mut::<Pos>(entity).unwrap();
+
+            let _entities = command_buffer.insert(
+                (),
+                vec![
+                    (Pos(1., 2., 3.), Vel(1., 2., 3.)),
+                    (Pos(1., 2., 3.), Vel(1., 2., 3.)),
+                ],
+            );
+        });
+
+    let thread_local_example = Box::new(|world: &mut World| {
+        // This is an example of a thread local system which has full, exclusive mutable access to the world.
+        let query = <(Write<Pos>, Read<Vel>)>::query();
+        for (mut pos, vel) in query.iter(world) {
+            pos.0 += vel.0;
+            pos.1 += vel.1;
+            pos.2 += vel.2;
+        }
+    });
+
+    let mut schedule = Schedule::builder()
+        .add_system(update_positions)
+        .add_system(command_buffer_usage)
+        // This flushes all command buffers of all systems.
+        .flush()
+        // a thread local system or function will wait for all previous systems to finish running,
+        // and then take exclusive access of the world.
+        .add_thread_local_fn(thread_local_example)
+        .build();
+
+    // Execute a frame of the schedule.
     schedule.execute(&mut world);
 }

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -357,7 +357,7 @@ impl legion::de::WorldDeserializer for DeserializeImpl {
     fn deserialize_entities<'de, D: Deserializer<'de>>(
         &self,
         deserializer: D,
-        entity_allocator: &mut EntityAllocator,
+        entity_allocator: &EntityAllocator,
         entities: &mut Vec<Entity>,
     ) -> Result<(), <D as Deserializer<'de>>::Error> {
         let entity_uuids = <Vec<uuid::Bytes> as Deserialize>::deserialize(deserializer)?;

--- a/src/borrow.rs
+++ b/src/borrow.rs
@@ -25,9 +25,7 @@ pub struct AtomicRefCell<T> {
 }
 
 impl<T: Default> Default for AtomicRefCell<T> {
-    fn default() -> Self {
-        Self::new(T::default())
-    }
+    fn default() -> Self { Self::new(T::default()) }
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for AtomicRefCell<T> {
@@ -54,14 +52,10 @@ impl<T> AtomicRefCell<T> {
     /// Runtime borrow checking is only conducted in builds with `debug_assertions` enabled. Release
     /// builds assume proper resource access and will cause undefined behavior with improper use.
     #[inline(always)]
-    pub fn get(&self) -> Ref<T> {
-        self.try_get().unwrap()
-    }
+    pub fn get(&self) -> Ref<T> { self.try_get().unwrap() }
 
     /// Unwrap the value from the RefCell and kill it, returning the value.
-    pub fn into_inner(self) -> T {
-        self.value.into_inner()
-    }
+    pub fn into_inner(self) -> T { self.value.into_inner() }
 
     /// Retrieve an immutable `Ref` wrapped reference of `&T`. This is the safe version of `get`
     /// providing an error result on failure.
@@ -128,9 +122,7 @@ impl<T> AtomicRefCell<T> {
     /// Runtime borrow checking is only conducted in builds with `debug_assertions` enabled. Release
     /// builds assume proper resource access and will cause undefined behavior with improper use.
     #[inline(always)]
-    pub fn get_mut(&self) -> RefMut<T> {
-        self.try_get_mut().unwrap()
-    }
+    pub fn get_mut(&self) -> RefMut<T> { self.try_get_mut().unwrap() }
 
     /// Retrieve a mutable `RefMut` wrapped reference of `&mut T`. This is the safe version of
     /// `get_mut` providing an error result on failure.
@@ -207,9 +199,7 @@ pub trait UnsafeClone {
 }
 
 impl<A: UnsafeClone, B: UnsafeClone> UnsafeClone for (A, B) {
-    unsafe fn clone(&self) -> Self {
-        (self.0.clone(), self.1.clone())
-    }
+    unsafe fn clone(&self) -> Self { (self.0.clone(), self.1.clone()) }
 }
 
 #[derive(Debug)]
@@ -222,21 +212,15 @@ pub struct Shared<'a> {
 
 impl<'a> Shared<'a> {
     #[cfg(debug_assertions)]
-    fn new(state: &'a AtomicIsize) -> Self {
-        Self { state }
-    }
+    fn new(state: &'a AtomicIsize) -> Self { Self { state } }
     #[cfg(not(debug_assertions))]
     #[inline(always)]
-    fn new(_: &'a AtomicIsize) -> Self {
-        Self { state: PhantomData }
-    }
+    fn new(_: &'a AtomicIsize) -> Self { Self { state: PhantomData } }
 }
 
 #[cfg(debug_assertions)]
 impl<'a> Drop for Shared<'a> {
-    fn drop(&mut self) {
-        self.state.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
-    }
+    fn drop(&mut self) { self.state.fetch_sub(1, std::sync::atomic::Ordering::SeqCst); }
 }
 
 impl<'a> Clone for Shared<'a> {
@@ -249,9 +233,7 @@ impl<'a> Clone for Shared<'a> {
 }
 
 impl<'a> UnsafeClone for Shared<'a> {
-    unsafe fn clone(&self) -> Self {
-        Clone::clone(&self)
-    }
+    unsafe fn clone(&self) -> Self { Clone::clone(&self) }
 }
 
 #[derive(Debug)]
@@ -264,21 +246,15 @@ pub struct Exclusive<'a> {
 
 impl<'a> Exclusive<'a> {
     #[cfg(debug_assertions)]
-    fn new(state: &'a AtomicIsize) -> Self {
-        Self { state }
-    }
+    fn new(state: &'a AtomicIsize) -> Self { Self { state } }
     #[cfg(not(debug_assertions))]
     #[inline(always)]
-    fn new(_: &'a AtomicIsize) -> Self {
-        Self { state: PhantomData }
-    }
+    fn new(_: &'a AtomicIsize) -> Self { Self { state: PhantomData } }
 }
 
 #[cfg(debug_assertions)]
 impl<'a> Drop for Exclusive<'a> {
-    fn drop(&mut self) {
-        self.state.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-    }
+    fn drop(&mut self) { self.state.fetch_add(1, std::sync::atomic::Ordering::SeqCst); }
 }
 
 impl<'a> UnsafeClone for Exclusive<'a> {
@@ -300,16 +276,12 @@ pub struct Ref<'a, T: 'a> {
 
 impl<'a, T: 'a> Clone for Ref<'a, T> {
     #[inline(always)]
-    fn clone(&self) -> Self {
-        Ref::new(Clone::clone(&self.borrow), self.value)
-    }
+    fn clone(&self) -> Self { Ref::new(Clone::clone(&self.borrow), self.value) }
 }
 
 impl<'a, T: 'a> Ref<'a, T> {
     #[inline(always)]
-    pub fn new(borrow: Shared<'a>, value: &'a T) -> Self {
-        Self { borrow, value }
-    }
+    pub fn new(borrow: Shared<'a>, value: &'a T) -> Self { Self { borrow, value } }
 
     #[inline(always)]
     pub fn map_into<K: 'a, F: FnMut(&'a T) -> K>(self, mut f: F) -> RefMap<'a, K> {
@@ -327,41 +299,31 @@ impl<'a, T: 'a> Ref<'a, T> {
     ///
     /// Ensure that you still follow all safety guidelines of this mapped ref.
     #[inline(always)]
-    pub unsafe fn deconstruct(self) -> (Shared<'a>, &'a T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (Shared<'a>, &'a T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for Ref<'a, T> {
     type Target = T;
 
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for Ref<'a, T> {
     #[inline(always)]
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for Ref<'a, T> {
     #[inline(always)]
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 impl<'a, T> PartialEq for Ref<'a, T>
 where
     T: 'a + PartialEq,
 {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
+    fn eq(&self, other: &Self) -> bool { self.value == other.value }
 }
 impl<'a, T> Eq for Ref<'a, T> where T: 'a + Eq {}
 
@@ -377,18 +339,14 @@ impl<'a, T> Ord for Ref<'a, T>
 where
     T: 'a + Ord,
 {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.value.cmp(&other.value)
-    }
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering { self.value.cmp(&other.value) }
 }
 
 impl<'a, T> Hash for Ref<'a, T>
 where
     T: 'a + Hash,
 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-    }
+    fn hash<H: Hasher>(&self, state: &mut H) { self.value.hash(state); }
 }
 
 #[derive(Debug)]
@@ -401,9 +359,7 @@ pub struct RefMut<'a, T: 'a> {
 
 impl<'a, T: 'a> RefMut<'a, T> {
     #[inline(always)]
-    pub fn new(borrow: Exclusive<'a>, value: &'a mut T) -> Self {
-        Self { borrow, value }
-    }
+    pub fn new(borrow: Exclusive<'a>, value: &'a mut T) -> Self { Self { borrow, value } }
 
     #[inline(always)]
     pub fn map_into<K: 'a, F: FnMut(&mut T) -> K>(mut self, mut f: F) -> RefMapMut<'a, K> {
@@ -416,9 +372,7 @@ impl<'a, T: 'a> RefMut<'a, T> {
     ///
     /// Ensure that you still follow all safety guidelines of this mapped ref.
     #[inline(always)]
-    pub unsafe fn deconstruct(self) -> (Exclusive<'a>, &'a mut T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (Exclusive<'a>, &'a mut T) { (self.borrow, self.value) }
 
     #[inline(always)]
     pub fn split<First, Rest, F: Fn(&'a mut T) -> (&'a mut First, &'a mut Rest)>(
@@ -437,39 +391,29 @@ impl<'a, T: 'a> Deref for RefMut<'a, T> {
     type Target = T;
 
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
+    fn deref(&self) -> &Self::Target { self.value }
 }
 
 impl<'a, T: 'a> DerefMut for RefMut<'a, T> {
     #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for RefMut<'a, T> {
     #[inline(always)]
-    fn as_ref(&self) -> &T {
-        self.value
-    }
+    fn as_ref(&self) -> &T { self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMut<'a, T> {
     #[inline(always)]
-    fn borrow(&self) -> &T {
-        self.value
-    }
+    fn borrow(&self) -> &T { self.value }
 }
 
 impl<'a, T> PartialEq for RefMut<'a, T>
 where
     T: 'a + PartialEq,
 {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
+    fn eq(&self, other: &Self) -> bool { self.value == other.value }
 }
 impl<'a, T> Eq for RefMut<'a, T> where T: 'a + Eq {}
 
@@ -485,18 +429,14 @@ impl<'a, T> Ord for RefMut<'a, T>
 where
     T: 'a + Ord,
 {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.value.cmp(&other.value)
-    }
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering { self.value.cmp(&other.value) }
 }
 
 impl<'a, T> Hash for RefMut<'a, T>
 where
     T: 'a + Hash,
 {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
-    }
+    fn hash<H: Hasher>(&self, state: &mut H) { self.value.hash(state); }
 }
 
 #[derive(Debug)]
@@ -509,9 +449,7 @@ pub struct RefMap<'a, T: 'a> {
 
 impl<'a, T: 'a> RefMap<'a, T> {
     #[inline(always)]
-    pub fn new(borrow: Shared<'a>, value: T) -> Self {
-        Self { borrow, value }
-    }
+    pub fn new(borrow: Shared<'a>, value: T) -> Self { Self { borrow, value } }
 
     #[inline(always)]
     pub fn map_into<K: 'a, F: FnMut(&mut T) -> K>(mut self, mut f: F) -> RefMap<'a, K> {
@@ -524,32 +462,24 @@ impl<'a, T: 'a> RefMap<'a, T> {
     ///
     /// Ensure that you still follow all safety guidelines of this  mapped ref.
     #[inline(always)]
-    pub unsafe fn deconstruct(self) -> (Shared<'a>, T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (Shared<'a>, T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for RefMap<'a, T> {
     type Target = T;
 
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
+    fn deref(&self) -> &Self::Target { &self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for RefMap<'a, T> {
     #[inline(always)]
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
+    fn as_ref(&self) -> &T { &self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMap<'a, T> {
     #[inline(always)]
-    fn borrow(&self) -> &T {
-        &self.value
-    }
+    fn borrow(&self) -> &T { &self.value }
 }
 
 #[derive(Debug)]
@@ -562,9 +492,7 @@ pub struct RefMapMut<'a, T: 'a> {
 
 impl<'a, T: 'a> RefMapMut<'a, T> {
     #[inline(always)]
-    pub fn new(borrow: Exclusive<'a>, value: T) -> Self {
-        Self { borrow, value }
-    }
+    pub fn new(borrow: Exclusive<'a>, value: T) -> Self { Self { borrow, value } }
 
     #[inline(always)]
     pub fn map_into<K: 'a, F: FnMut(&mut T) -> K>(mut self, mut f: F) -> RefMapMut<'a, K> {
@@ -580,39 +508,29 @@ impl<'a, T: 'a> RefMapMut<'a, T> {
     ///
     /// Ensure that you still follow all safety guidelines of this mutable mapped ref.
     #[inline(always)]
-    pub unsafe fn deconstruct(self) -> (Exclusive<'a>, T) {
-        (self.borrow, self.value)
-    }
+    pub unsafe fn deconstruct(self) -> (Exclusive<'a>, T) { (self.borrow, self.value) }
 }
 
 impl<'a, T: 'a> Deref for RefMapMut<'a, T> {
     type Target = T;
 
     #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
+    fn deref(&self) -> &Self::Target { &self.value }
 }
 
 impl<'a, T: 'a> DerefMut for RefMapMut<'a, T> {
     #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.value }
 }
 
 impl<'a, T: 'a> AsRef<T> for RefMapMut<'a, T> {
     #[inline(always)]
-    fn as_ref(&self) -> &T {
-        &self.value
-    }
+    fn as_ref(&self) -> &T { &self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMapMut<'a, T> {
     #[inline(always)]
-    fn borrow(&self) -> &T {
-        &self.value
-    }
+    fn borrow(&self) -> &T { &self.value }
 }
 
 #[derive(Debug)]
@@ -625,9 +543,7 @@ pub struct RefIter<'a, T: 'a, I: Iterator<Item = &'a T>> {
 
 impl<'a, T: 'a, I: Iterator<Item = &'a T>> RefIter<'a, T, I> {
     #[inline(always)]
-    pub fn new(borrow: Shared<'a>, iter: I) -> Self {
-        Self { borrow, iter }
-    }
+    pub fn new(borrow: Shared<'a>, iter: I) -> Self { Self { borrow, iter } }
 }
 
 impl<'a, T: 'a, I: Iterator<Item = &'a T>> Iterator for RefIter<'a, T, I> {
@@ -642,9 +558,7 @@ impl<'a, T: 'a, I: Iterator<Item = &'a T>> Iterator for RefIter<'a, T, I> {
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'a, T: 'a, I: Iterator<Item = &'a T> + ExactSizeIterator> ExactSizeIterator
@@ -720,9 +634,7 @@ pub struct RefIterMut<'a, T: 'a, I: Iterator<Item = &'a mut T>> {
 
 impl<'a, T: 'a, I: Iterator<Item = &'a mut T>> RefIterMut<'a, T, I> {
     #[inline(always)]
-    pub fn new(borrow: Exclusive<'a>, iter: I) -> Self {
-        Self { borrow, iter }
-    }
+    pub fn new(borrow: Exclusive<'a>, iter: I) -> Self { Self { borrow, iter } }
 }
 
 impl<'a, T: 'a, I: Iterator<Item = &'a mut T>> Iterator for RefIterMut<'a, T, I> {
@@ -737,9 +649,7 @@ impl<'a, T: 'a, I: Iterator<Item = &'a mut T>> Iterator for RefIterMut<'a, T, I>
         }
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
-    }
+    fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
 }
 
 impl<'a, T: 'a, I: Iterator<Item = &'a mut T> + ExactSizeIterator> ExactSizeIterator

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,8 +40,12 @@ where
         world.insert(consumed.tags, consumed.components);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { self.write_components.clone() }
-    fn write_tags(&self) -> Vec<TagTypeId> { self.write_tags.clone() }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        self.write_components.clone()
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        self.write_tags.clone()
+    }
 }
 
 #[derive(Derivative)]
@@ -67,18 +71,28 @@ where
         world.insert_buffered(&consumed.entities, consumed.tags, consumed.components);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { self.write_components.clone() }
-    fn write_tags(&self) -> Vec<TagTypeId> { self.write_tags.clone() }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        self.write_components.clone()
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        self.write_tags.clone()
+    }
 }
 
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""))]
 struct DeleteEntityCommand(Entity);
 impl WorldWritable for DeleteEntityCommand {
-    fn write(self: Arc<Self>, world: &mut World) { world.delete(self.0); }
+    fn write(self: Arc<Self>, world: &mut World) {
+        world.delete(self.0);
+    }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
-    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        Vec::with_capacity(0)
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        Vec::with_capacity(0)
+    }
 }
 
 #[derive(Derivative)]
@@ -97,8 +111,12 @@ where
         world.add_tag(consumed.entity, consumed.tag)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
-    fn write_tags(&self) -> Vec<TagTypeId> { vec![TagTypeId::of::<T>()] }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        Vec::with_capacity(0)
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        vec![TagTypeId::of::<T>()]
+    }
 }
 
 #[derive(Derivative)]
@@ -111,10 +129,16 @@ impl<T> WorldWritable for RemoveTagCommand<T>
 where
     T: Tag,
 {
-    fn write(self: Arc<Self>, world: &mut World) { world.remove_tag::<T>(self.entity) }
+    fn write(self: Arc<Self>, world: &mut World) {
+        world.remove_tag::<T>(self.entity)
+    }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
-    fn write_tags(&self) -> Vec<TagTypeId> { vec![TagTypeId::of::<T>()] }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        Vec::with_capacity(0)
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        vec![TagTypeId::of::<T>()]
+    }
 }
 
 #[derive(Derivative)]
@@ -134,8 +158,12 @@ where
         world.add_component::<C>(consumed.entity, consumed.component)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }
-    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        vec![ComponentTypeId::of::<C>()]
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        Vec::with_capacity(0)
+    }
 }
 
 #[derive(Derivative)]
@@ -148,10 +176,16 @@ impl<C> WorldWritable for RemoveComponentCommand<C>
 where
     C: Component,
 {
-    fn write(self: Arc<Self>, world: &mut World) { world.remove_component::<C>(self.entity) }
+    fn write(self: Arc<Self>, world: &mut World) {
+        world.remove_component::<C>(self.entity)
+    }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }
-    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
+    fn write_components(&self) -> Vec<ComponentTypeId> {
+        vec![ComponentTypeId::of::<C>()]
+    }
+    fn write_tags(&self) -> Vec<TagTypeId> {
+        Vec::with_capacity(0)
+    }
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -224,13 +258,19 @@ pub enum CommandError {
     EntityBlockFull,
 }
 impl std::fmt::Display for CommandError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "CommandError") }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CommandError")
+    }
 }
 
 impl std::error::Error for CommandError {
-    fn description(&self) -> &str { "CommandError" }
+    fn description(&self) -> &str {
+        "CommandError"
+    }
 
-    fn cause(&self) -> Option<&dyn std::error::Error> { None }
+    fn cause(&self) -> Option<&dyn std::error::Error> {
+        None
+    }
 }
 
 #[derive(Default)]
@@ -245,6 +285,19 @@ unsafe impl Send for CommandBuffer {}
 unsafe impl Sync for CommandBuffer {}
 
 impl CommandBuffer {
+    pub fn from_world_with_capacity(world: &mut World, capacity: usize) -> Self {
+        // Pull  free entities from the world.
+
+        let free_list =
+            SmallVec::from_iter((0..capacity).map(|_| world.entity_allocator.create_entity()));
+
+        Self {
+            free_list,
+            commands: Default::default(),
+            used_list: Default::default(),
+        }
+    }
+
     pub fn from_world(world: &mut World) -> Self {
         // Pull  free entities from the world.
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -334,6 +334,14 @@ impl CommandBuffer {
     pub fn write(&mut self, world: &mut World) {
         tracing::trace!("Draining command buffer");
 
+        let empty = Vec::from_iter((0..self.used_list.len()).map(|_| ()));
+        world.insert_buffered(
+            self.used_list.as_slice(),
+            (),
+            IntoComponentSource::into(empty),
+        );
+        self.used_list.clear();
+
         while let Some(command) = self.commands.get_mut().pop_back() {
             match command {
                 EntityCommand::WriteWorld(ptr) => ptr.write(world),

--- a/src/command.rs
+++ b/src/command.rs
@@ -40,12 +40,8 @@ where
         world.insert(consumed.tags, consumed.components);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        self.write_components.clone()
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        self.write_tags.clone()
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { self.write_components.clone() }
+    fn write_tags(&self) -> Vec<TagTypeId> { self.write_tags.clone() }
 }
 
 #[derive(Derivative)]
@@ -71,28 +67,18 @@ where
         world.insert_buffered(&consumed.entities, consumed.tags, consumed.components);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        self.write_components.clone()
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        self.write_tags.clone()
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { self.write_components.clone() }
+    fn write_tags(&self) -> Vec<TagTypeId> { self.write_tags.clone() }
 }
 
 #[derive(Derivative)]
 #[derivative(Debug(bound = ""))]
 struct DeleteEntityCommand(Entity);
 impl WorldWritable for DeleteEntityCommand {
-    fn write(self: Arc<Self>, world: &mut World) {
-        world.delete(self.0);
-    }
+    fn write(self: Arc<Self>, world: &mut World) { world.delete(self.0); }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        Vec::with_capacity(0)
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        Vec::with_capacity(0)
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
+    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
 }
 
 #[derive(Derivative)]
@@ -111,12 +97,8 @@ where
         world.add_tag(consumed.entity, consumed.tag)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        Vec::with_capacity(0)
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        vec![TagTypeId::of::<T>()]
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
+    fn write_tags(&self) -> Vec<TagTypeId> { vec![TagTypeId::of::<T>()] }
 }
 
 #[derive(Derivative)]
@@ -129,16 +111,10 @@ impl<T> WorldWritable for RemoveTagCommand<T>
 where
     T: Tag,
 {
-    fn write(self: Arc<Self>, world: &mut World) {
-        world.remove_tag::<T>(self.entity)
-    }
+    fn write(self: Arc<Self>, world: &mut World) { world.remove_tag::<T>(self.entity) }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        Vec::with_capacity(0)
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        vec![TagTypeId::of::<T>()]
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
+    fn write_tags(&self) -> Vec<TagTypeId> { vec![TagTypeId::of::<T>()] }
 }
 
 #[derive(Derivative)]
@@ -158,12 +134,8 @@ where
         world.add_component::<C>(consumed.entity, consumed.component)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        vec![ComponentTypeId::of::<C>()]
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        Vec::with_capacity(0)
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }
+    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
 }
 
 #[derive(Derivative)]
@@ -176,16 +148,10 @@ impl<C> WorldWritable for RemoveComponentCommand<C>
 where
     C: Component,
 {
-    fn write(self: Arc<Self>, world: &mut World) {
-        world.remove_component::<C>(self.entity)
-    }
+    fn write(self: Arc<Self>, world: &mut World) { world.remove_component::<C>(self.entity) }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        vec![ComponentTypeId::of::<C>()]
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        Vec::with_capacity(0)
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }
+    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -258,19 +224,13 @@ pub enum CommandError {
     EntityBlockFull,
 }
 impl std::fmt::Display for CommandError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CommandError")
-    }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "CommandError") }
 }
 
 impl std::error::Error for CommandError {
-    fn description(&self) -> &str {
-        "CommandError"
-    }
+    fn description(&self) -> &str { "CommandError" }
 
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        None
-    }
+    fn cause(&self) -> Option<&dyn std::error::Error> { None }
 }
 
 #[derive(Default)]
@@ -393,7 +353,6 @@ impl CommandBuffer {
         C: 'static + IntoComponentSource,
     {
         let components = components.into();
-
         if components.len() > self.free_list.len() {
             return Err(CommandError::EntityBlockFull);
         }

--- a/src/command.rs
+++ b/src/command.rs
@@ -31,9 +31,9 @@ struct InsertBufferedCommand<T, C> {
     entities: Vec<Entity>,
 }
 impl<T, C> WorldWritable for InsertBufferedCommand<T, C>
-    where
-        T: TagSet + TagLayout + for<'a> Filter<ChunksetFilterData<'a>>,
-        C: ComponentSource,
+where
+    T: TagSet + TagLayout + for<'a> Filter<ChunksetFilterData<'a>>,
+    C: ComponentSource,
 {
     fn write(self: Arc<Self>, world: &mut World) {
         let consumed = Arc::try_unwrap(self).unwrap();
@@ -54,7 +54,6 @@ struct InsertCommand<T, C> {
     tags: T,
     #[derivative(Debug = "ignore")]
     components: C,
-
 }
 impl<T, C> WorldWritable for InsertCommand<T, C>
 where
@@ -347,9 +346,9 @@ impl CommandBuffer {
     }
 
     pub fn insert_unbuffered<T, C>(&mut self, tags: T, components: C)
-        where
-            T: 'static + TagSet + TagLayout + for<'a> Filter<ChunksetFilterData<'a>>,
-            C: 'static + IntoComponentSource,
+    where
+        T: 'static + TagSet + TagLayout + for<'a> Filter<ChunksetFilterData<'a>>,
+        C: 'static + IntoComponentSource,
     {
         self.commands
             .get_mut()

--- a/src/command.rs
+++ b/src/command.rs
@@ -226,8 +226,6 @@ impl std::fmt::Display for CommandError {
 }
 
 impl std::error::Error for CommandError {
-    fn description(&self) -> &str { "CommandError" }
-
     fn cause(&self) -> Option<&dyn std::error::Error> { None }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -48,12 +48,8 @@ where
         world.insert_buffered(&consumed.entities, consumed.tags, consumed.components);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        self.write_components.clone()
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        self.write_tags.clone()
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { self.write_components.clone() }
+    fn write_tags(&self) -> Vec<TagTypeId> { self.write_tags.clone() }
 }
 
 #[derive(Derivative)]
@@ -82,12 +78,8 @@ where
         world.insert(consumed.tags, consumed.components);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        self.write_components.clone()
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        self.write_tags.clone()
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { self.write_components.clone() }
+    fn write_tags(&self) -> Vec<TagTypeId> { self.write_tags.clone() }
 }
 
 #[derive(Derivative)]
@@ -99,12 +91,8 @@ impl WorldWritable for DeleteEntityCommand {
         world.delete(self.0);
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        Vec::with_capacity(0)
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        Vec::with_capacity(0)
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
+    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
 }
 
 #[derive(Derivative)]
@@ -124,12 +112,8 @@ where
         world.add_tag(consumed.entity, consumed.tag)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        Vec::with_capacity(0)
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        vec![TagTypeId::of::<T>()]
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
+    fn write_tags(&self) -> Vec<TagTypeId> { vec![TagTypeId::of::<T>()] }
 }
 
 #[derive(Derivative)]
@@ -151,12 +135,8 @@ where
         world.remove_tag::<T>(self.entity)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        Vec::with_capacity(0)
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        vec![TagTypeId::of::<T>()]
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { Vec::with_capacity(0) }
+    fn write_tags(&self) -> Vec<TagTypeId> { vec![TagTypeId::of::<T>()] }
 }
 
 #[derive(Derivative)]
@@ -183,12 +163,8 @@ where
             .unwrap();
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        vec![ComponentTypeId::of::<C>()]
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        Vec::with_capacity(0)
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }
+    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
 }
 
 #[derive(Derivative)]
@@ -206,12 +182,8 @@ where
         world.remove_component::<C>(self.entity)
     }
 
-    fn write_components(&self) -> Vec<ComponentTypeId> {
-        vec![ComponentTypeId::of::<C>()]
-    }
-    fn write_tags(&self) -> Vec<TagTypeId> {
-        Vec::with_capacity(0)
-    }
+    fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }
+    fn write_tags(&self) -> Vec<TagTypeId> { Vec::with_capacity(0) }
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -284,15 +256,11 @@ pub enum CommandError {
     EntityBlockFull,
 }
 impl std::fmt::Display for CommandError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CommandError")
-    }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "CommandError") }
 }
 
 impl std::error::Error for CommandError {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        None
-    }
+    fn cause(&self) -> Option<&dyn std::error::Error> { None }
 }
 
 #[derive(Default)]
@@ -499,14 +467,10 @@ impl CommandBuffer {
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
-        self.commands.get().len()
-    }
+    pub fn len(&self) -> usize { self.commands.get().len() }
 
     #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.commands.get().len() == 0
-    }
+    pub fn is_empty(&self) -> bool { self.commands.get().len() == 0 }
 }
 
 #[cfg(test)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -129,7 +129,9 @@ where
 {
     fn write(self: Arc<Self>, world: &mut World) {
         let consumed = Arc::try_unwrap(self).unwrap();
-        world.add_component::<C>(consumed.entity, consumed.component)
+        world
+            .add_component::<C>(consumed.entity, consumed.component)
+            .unwrap();
     }
 
     fn write_components(&self) -> Vec<ComponentTypeId> { vec![ComponentTypeId::of::<C>()] }

--- a/src/command.rs
+++ b/src/command.rs
@@ -259,6 +259,7 @@ impl CommandBuffer {
         }
     }
 
+    #[allow(clippy::comparison_chain)]
     pub fn resize(&mut self, world: &mut World) {
         let entity_count = world.command_buffer_size();
         if self.free_list.len() < entity_count {

--- a/src/command.rs
+++ b/src/command.rs
@@ -263,7 +263,7 @@ impl CommandBuffer {
     pub fn resize(&mut self, world: &mut World) {
         let entity_count = world.command_buffer_size();
         if self.free_list.len() < entity_count {
-            (entity_count - self.free_list.len()..entity_count)
+            (self.free_list.len()..entity_count)
                 .for_each(|_| self.free_list.push(world.entity_allocator.create_entity()));
         } else if self.free_list.len() > entity_count {
             // Free the entities

--- a/src/de.rs
+++ b/src/de.rs
@@ -77,7 +77,7 @@ pub trait WorldDeserializer {
     fn deserialize_entities<'de, D: Deserializer<'de>>(
         &self,
         deserializer: D,
-        entity_allocator: &mut EntityAllocator,
+        entity_allocator: &EntityAllocator,
         entities: &mut Vec<Entity>,
     ) -> Result<(), <D as Deserializer<'de>>::Error>;
 }
@@ -625,7 +625,7 @@ impl<'de, 'a, 'b, WD: WorldDeserializer> DeserializeSeed<'de> for EntitiesDeseri
         let mut entities = Vec::new();
         self.user.deserialize_entities(
             deserializer,
-            &mut self.world.entity_allocator,
+            &self.world.entity_allocator,
             &mut entities,
         )?;
         let archetype = &mut self.world.storage_mut().archetypes_mut()[self.archetype_idx];

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -182,9 +182,6 @@ impl EntityAllocator {
         }
     }
 
-    pub(crate) fn get_block(&mut self) -> EntityBlock { self.allocator.lock().allocate() }
-    pub(crate) fn push_block(&mut self, block: EntityBlock) { self.blocks.push(block); }
-
     /// Determines if the given `Entity` is considered alive.
     pub fn is_alive(&self, entity: Entity) -> bool {
         self.blocks

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,4 +1,4 @@
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use std::fmt::Display;
 use std::num::Wrapping;
 use std::sync::Arc;
@@ -166,25 +166,24 @@ impl EntityBlock {
 }
 
 /// Manages the allocation and deletion of `Entity` IDs within a world.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EntityAllocator {
     allocator: Arc<Mutex<BlockAllocator>>,
-    blocks: Vec<EntityBlock>,
-    entity_buffer: Vec<Entity>,
+    blocks: Arc<RwLock<Vec<EntityBlock>>>,
 }
 
 impl EntityAllocator {
     pub(crate) fn new(allocator: Arc<Mutex<BlockAllocator>>) -> Self {
         EntityAllocator {
             allocator,
-            blocks: Vec::new(),
-            entity_buffer: Vec::new(),
+            blocks: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
     /// Determines if the given `Entity` is considered alive.
     pub fn is_alive(&self, entity: Entity) -> bool {
         self.blocks
+            .read()
             .iter()
             .filter_map(|b| b.is_alive(entity))
             .nth(0)
@@ -192,32 +191,26 @@ impl EntityAllocator {
     }
 
     /// Allocates a new unused `Entity` ID.
-    pub fn create_entity(&mut self) -> Entity {
-        let entity = if let Some(entity) = self
-            .blocks
-            .iter_mut()
-            .rev()
-            .filter_map(|b| b.allocate())
-            .nth(0)
-        {
+    pub fn create_entity(&self) -> Entity {
+        let mut blocks = self.blocks.write();
+
+        if let Some(entity) = blocks.iter_mut().rev().filter_map(|b| b.allocate()).nth(0) {
             entity
         } else {
             let mut block = self.allocator.lock().allocate();
             let entity = block.allocate().unwrap();
-            self.blocks.push(block);
+            blocks.push(block);
             entity
-        };
-
-        self.entity_buffer.push(entity.clone());
-        entity
+        }
     }
 
-    pub(crate) fn delete_entity(&mut self, entity: Entity) -> Option<EntityLocation> {
-        self.blocks.iter_mut().find_map(|b| b.free(entity))
+    pub(crate) fn delete_entity(&self, entity: Entity) -> Option<EntityLocation> {
+        self.blocks.write().iter_mut().find_map(|b| b.free(entity))
     }
 
-    pub(crate) fn set_location(&mut self, entity: EntityIndex, location: EntityLocation) {
+    pub(crate) fn set_location(&self, entity: EntityIndex, location: EntityLocation) {
         self.blocks
+            .write()
             .iter_mut()
             .rev()
             .find(|b| b.in_range(entity))
@@ -227,24 +220,21 @@ impl EntityAllocator {
 
     pub(crate) fn get_location(&self, entity: EntityIndex) -> Option<EntityLocation> {
         self.blocks
+            .read()
             .iter()
             .find(|b| b.in_range(entity))
             .and_then(|b| b.get_location(entity))
     }
 
-    pub(crate) fn allocation_buffer(&self) -> &[Entity] { self.entity_buffer.as_slice() }
-
-    pub(crate) fn clear_allocation_buffer(&mut self) { self.entity_buffer.clear(); }
-
-    pub(crate) fn merge(&mut self, mut other: EntityAllocator) {
+    pub(crate) fn merge(&self, other: EntityAllocator) {
         assert!(Arc::ptr_eq(&self.allocator, &other.allocator));
-        self.blocks.append(&mut other.blocks);
+        self.blocks.write().append(&mut other.blocks.write());
     }
 }
 
 impl Drop for EntityAllocator {
     fn drop(&mut self) {
-        for block in self.blocks.drain(..) {
+        for block in self.blocks.write().drain(..) {
             self.allocator.lock().free(block);
         }
     }
@@ -257,13 +247,13 @@ mod tests {
 
     #[test]
     fn create_entity() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
         allocator.create_entity();
     }
 
     #[test]
     fn create_entity_many() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
 
         for _ in 0..512 {
             allocator.create_entity();
@@ -272,7 +262,7 @@ mod tests {
 
     #[test]
     fn create_entity_many_blocks() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
 
         for _ in 0..3000 {
             allocator.create_entity();
@@ -281,7 +271,7 @@ mod tests {
 
     #[test]
     fn create_entity_recreate() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
 
         for _ in 0..3 {
             let entities: Vec<Entity> = (0..512).map(|_| allocator.create_entity()).collect();
@@ -293,7 +283,7 @@ mod tests {
 
     #[test]
     fn is_alive_allocated() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
         let entity = allocator.create_entity();
 
         assert_eq!(true, allocator.is_alive(entity));
@@ -309,7 +299,7 @@ mod tests {
 
     #[test]
     fn is_alive_killed() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
         let entity = allocator.create_entity();
         allocator.delete_entity(entity);
 
@@ -318,7 +308,7 @@ mod tests {
 
     #[test]
     fn delete_entity_was_alive() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
         let entity = allocator.create_entity();
 
         assert_eq!(true, allocator.delete_entity(entity).is_some());
@@ -326,7 +316,7 @@ mod tests {
 
     #[test]
     fn delete_entity_was_dead() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
         let entity = allocator.create_entity();
         allocator.delete_entity(entity);
 
@@ -335,7 +325,7 @@ mod tests {
 
     #[test]
     fn delete_entity_was_unallocated() {
-        let mut allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
+        let allocator = EntityAllocator::new(Arc::from(Mutex::new(BlockAllocator::new())));
         let entity = Entity::new(10 as EntityIndex, Wrapping(10));
 
         assert_eq!(None, allocator.delete_entity(entity));
@@ -344,8 +334,8 @@ mod tests {
     #[test]
     fn multiple_allocators_unique_ids() {
         let blocks = Arc::from(Mutex::new(BlockAllocator::new()));
-        let mut allocator_a = EntityAllocator::new(blocks.clone());
-        let mut allocator_b = EntityAllocator::new(blocks.clone());
+        let allocator_a = EntityAllocator::new(blocks.clone());
+        let allocator_b = EntityAllocator::new(blocks.clone());
 
         let mut entities_a = HashSet::<Entity>::default();
         let mut entities_b = HashSet::<Entity>::default();

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -45,7 +45,7 @@ impl ResourceTypeId {
 /// resources.insert(TypeB(12));
 ///
 /// {
-///     let (a, mut b) = <(Read<TypeA>, Write<TypeB>)>::fetch(&resources);
+///     let (a, mut b) = <(Read<TypeA>, Write<TypeB>)>::fetch_mut(&mut resources);
 ///     assert_ne!(a.0, b.0);
 ///     b.0 = a.0;
 /// }
@@ -339,7 +339,7 @@ impl<T: Resource> ResourceSet for Read<T> {
         let resource = resources
             .get::<T>()
             .unwrap_or_else(|| panic!("Failed to fetch resource!: {}", std::any::type_name::<T>()));
-        unsafe { PreparedRead::new(resource.deref() as *const T) }
+        PreparedRead::new(resource.deref() as *const T)
     }
 }
 impl<T: Resource> ResourceSet for Write<T> {
@@ -349,7 +349,7 @@ impl<T: Resource> ResourceSet for Write<T> {
         let mut resource = resources
             .get_mut::<T>()
             .unwrap_or_else(|| panic!("Failed to fetch resource!: {}", std::any::type_name::<T>()));
-        unsafe { PreparedWrite::new(resource.deref_mut() as *mut T) }
+        PreparedWrite::new(resource.deref_mut() as *mut T)
     }
 }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -302,6 +302,16 @@ impl Resources {
             _marker: Default::default(),
         })
     }
+
+    /// Performs merging of two resource storages, which occurs during a world merge.
+    /// This merge will retain any already-existant resources in the local world, while moving any
+    /// new resources from the source world into this one, consuming the resources.
+    pub fn merge(&mut self, mut other: Resources) {
+        // Merge resources, retaining our local ones but moving in any non-existant ones
+        for resource in other.storage.drain() {
+            self.storage.entry(resource.0).or_insert(resource.1);
+        }
+    }
 }
 
 impl ResourceSet for () {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -59,6 +59,11 @@ impl ResourceTypeId {
 pub trait ResourceSet: Send + Sync {
     type PreparedResources;
 
+    /// Fetches all defined resources, without checking mutability.
+    ///
+    /// # Safety
+    /// It is up to the end user to validate proper mutability rules across the resources being accessed.
+    ///
     unsafe fn fetch_unchecked(resources: &Resources) -> Self::PreparedResources;
 
     fn fetch_mut(resources: &mut Resources) -> Self::PreparedResources {

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -524,8 +524,9 @@ mod tests {
         #[derive(Clone, Copy, Debug, PartialEq)]
         struct TestComp(f32, f32, f32);
 
-        let system_one = SystemBuilder::new("one")
-            .build(move |cmd, _, _, _| cmd.insert((), vec![(TestComp(0., 0., 0.),)]));
+        let system_one = SystemBuilder::new("one").build(move |cmd, _, _, _| {
+            cmd.insert((), vec![(TestComp(0., 0., 0.),)]).unwrap();
+        });
         let system_two = SystemBuilder::new("two")
             .with_query(Write::<TestComp>::query())
             .build(move |_, world, _, query| assert_eq!(0, query.iter(world).count()));

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -226,6 +226,7 @@ impl Executor {
 
     /// Executes all systems and then flushes their command buffers.
     pub fn execute(&mut self, world: &mut World) {
+        self.resize_command_buffers(world);
         self.run_systems(world);
         self.flush_command_buffers(world);
     }
@@ -303,6 +304,13 @@ impl Executor {
                 }
             },
         );
+    }
+
+    /// Resizes all command buffers where appropriate to the world
+    pub fn resize_command_buffers(&mut self, world: &mut World) {
+        self.systems.iter().for_each(|system| {
+            system.command_buffer_mut().resize(world);
+        });
     }
 
     /// Flushes the recorded command buffers for all systems.

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -226,7 +226,6 @@ impl Executor {
 
     /// Executes all systems and then flushes their command buffers.
     pub fn execute(&mut self, world: &mut World) {
-        self.resize_command_buffers(world);
         self.run_systems(world);
         self.flush_command_buffers(world);
     }
@@ -236,6 +235,7 @@ impl Executor {
     /// Only enabled with par-schedule is disabled
     #[cfg(not(feature = "par-schedule"))]
     pub fn run_systems(&mut self, world: &mut World) {
+        self.resize_command_buffers(world);
         self.systems.iter_mut().for_each(|system| {
             system.run(world);
         });
@@ -249,6 +249,8 @@ impl Executor {
     /// Call from within `rayon::ThreadPool::install()` to execute within a specific thread pool.
     #[cfg(feature = "par-schedule")]
     pub fn run_systems(&mut self, world: &mut World) {
+        self.resize_command_buffers(world);
+
         rayon::join(
             || {},
             || {

--- a/src/system.rs
+++ b/src/system.rs
@@ -1395,7 +1395,7 @@ mod tests {
 
         let expected_copy = expected.clone();
         let mut system = SystemBuilder::<()>::new("TestSystem")
-            .with_query(<(Read::<Pos>, Read<Vel>)>::query())
+            .with_query(<(Read<Pos>, Read<Vel>)>::query())
             .build(move |_, world, _, query| {
                 let mut count = 0;
                 {
@@ -1428,7 +1428,9 @@ mod tests {
         #[derive(Default, Clone, Copy)]
         pub struct Balls(u32);
 
-        let components = (0..30000).map(|_|  (Pos(1., 2., 3.), Vel(0.1, 0.2, 0.3))).collect::<Vec<_>>();
+        let components = (0..30000)
+            .map(|_| (Pos(1., 2., 3.), Vel(0.1, 0.2, 0.3)))
+            .collect::<Vec<_>>();
 
         let mut expected = HashMap::<Entity, (Pos, Vel)>::new();
 
@@ -1438,10 +1440,9 @@ mod tests {
             }
         }
 
-
         let expected_copy = expected.clone();
         let mut system = SystemBuilder::<()>::new("TestSystem")
-            .with_query(<(Read::<Pos>, Read<Vel>)>::query())
+            .with_query(<(Read<Pos>, Read<Vel>)>::query())
             .build(move |command_buffer, world, _, query| {
                 let mut count = 0;
                 {
@@ -1465,7 +1466,6 @@ mod tests {
         system.prepare(&world);
         system.run(&world);
     }
-
 
     #[test]
     #[cfg(feature = "par-schedule")]
@@ -1725,4 +1725,3 @@ mod tests {
         });
     }
 }
-

--- a/src/system.rs
+++ b/src/system.rs
@@ -1412,7 +1412,9 @@ mod tests {
         system.prepare(&world);
         system.run(&world);
 
-        world.add_component(*(expected.keys().nth(0).unwrap()), Balls::default());
+        world
+            .add_component(*(expected.keys().nth(0).unwrap()), Balls::default())
+            .unwrap();
 
         system.prepare(&world);
         system.run(&world);

--- a/src/world.rs
+++ b/src/world.rs
@@ -49,7 +49,9 @@ pub struct Universe {
 
 impl Universe {
     /// Creates a new `Universe`.
-    pub fn new() -> Self { Self::default() }
+    pub fn new() -> Self {
+        Self::default()
+    }
 
     /// Creates a new `World` within this `Universe`.
     ///
@@ -78,7 +80,9 @@ impl Default for Universe {
 pub struct WorldId(usize);
 
 impl WorldId {
-    pub fn index(self) -> usize { self.0 }
+    pub fn index(self) -> usize {
+        self.0
+    }
 }
 
 /// Contains queryable collections of data associated with `Entity`s.
@@ -121,7 +125,9 @@ impl World {
     }
 
     #[inline]
-    pub fn command_buffer_size(&self) -> usize { self.command_buffer_size }
+    pub fn command_buffer_size(&self) -> usize {
+        self.command_buffer_size
+    }
 
     #[inline]
     pub fn set_command_buffer_size(&mut self, command_buffer_size: usize) {
@@ -157,12 +163,18 @@ impl World {
         self.storage_mut().subscribe(sender, filter);
     }
 
-    pub(crate) fn storage(&self) -> &Storage { unsafe { &*self.storage.get() } }
+    pub(crate) fn storage(&self) -> &Storage {
+        unsafe { &*self.storage.get() }
+    }
 
-    pub(crate) fn storage_mut(&mut self) -> &mut Storage { unsafe { &mut *self.storage.get() } }
+    pub(crate) fn storage_mut(&mut self) -> &mut Storage {
+        unsafe { &mut *self.storage.get() }
+    }
 
     /// Gets the unique ID of this world within its universe.
-    pub fn id(&self) -> WorldId { self.id }
+    pub fn id(&self) -> WorldId {
+        self.id
+    }
 
     /// Inserts new entities into the world.
     ///
@@ -476,10 +488,18 @@ impl World {
 
     /// Adds a component to an entity, or sets its value if the component is
     /// already present.
-    pub fn add_component<T: Component>(&mut self, entity: Entity, component: T) {
+    pub fn add_component<T: Component>(
+        &mut self,
+        entity: Entity,
+        component: T,
+    ) -> Result<(), &'static str> {
+        if !self.is_alive(entity) {
+            return Err("Attempted to add a component to a dead or non-existant entity.");
+        }
+
         if let Some(mut comp) = self.get_component_mut(entity) {
             *comp = component;
-            return;
+            return Ok(());
         }
 
         trace!(
@@ -511,6 +531,8 @@ impl World {
                 .push(&slice);
         }
         std::mem::forget(slice);
+
+        Ok(())
     }
 
     /// Removes a component from an entity.
@@ -663,7 +685,9 @@ impl World {
     }
 
     /// Determines if the given `Entity` is alive within this `World`.
-    pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
+    pub fn is_alive(&self, entity: Entity) -> bool {
+        self.entity_allocator.is_alive(entity)
+    }
 
     /// Iteratively defragments the world's internal memory.
     ///
@@ -831,7 +855,9 @@ impl World {
 }
 
 impl Default for World {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 /// Describes the types of a set of components attached to an entity.
@@ -1208,7 +1234,9 @@ struct DynamicComponentLayout<'a> {
 impl<'a> ComponentLayout for DynamicComponentLayout<'a> {
     type Filter = Self;
 
-    fn get_filter(&mut self) -> &mut Self::Filter { self }
+    fn get_filter(&mut self) -> &mut Self::Filter {
+        self
+    }
 
     fn tailor_archetype(&self, archetype: &mut ArchetypeDescription) {
         // copy components from existing archetype into new
@@ -1266,7 +1294,9 @@ unsafe impl<'a> Sync for DynamicTagLayout<'a> {}
 impl<'a> TagLayout for DynamicTagLayout<'a> {
     type Filter = Self;
 
-    fn get_filter(&mut self) -> &mut Self::Filter { self }
+    fn get_filter(&mut self) -> &mut Self::Filter {
+        self
+    }
 
     fn tailor_archetype(&self, archetype: &mut ArchetypeDescription) {
         // copy tags from existing archetype into new
@@ -1290,7 +1320,9 @@ impl<'a> TagLayout for DynamicTagLayout<'a> {
 impl<'a, 'b> Filter<ArchetypeFilterData<'b>> for DynamicTagLayout<'a> {
     type Iter = SliceVecIter<'b, TagTypeId>;
 
-    fn collect(&self, source: ArchetypeFilterData<'b>) -> Self::Iter { source.tag_types.iter() }
+    fn collect(&self, source: ArchetypeFilterData<'b>) -> Self::Iter {
+        source.tag_types.iter()
+    }
 
     fn is_match(&self, item: &<Self::Iter as Iterator>::Item) -> Option<bool> {
         Some(

--- a/src/world.rs
+++ b/src/world.rs
@@ -273,7 +273,7 @@ impl World {
                     .archetypes_mut()
                     .get_unchecked_mut(archetype_index)
             };
-            let chunk_index = archetype.get_free_chunk(chunk_set_index);
+            let chunk_index = archetype.get_free_chunk(chunk_set_index, 1);
             let chunk = unsafe {
                 archetype
                     .chunksets_mut()

--- a/src/world.rs
+++ b/src/world.rs
@@ -309,6 +309,10 @@ impl World {
     ///
     /// Returns `true` if the entity was deleted; else `false`.
     pub fn delete(&mut self, entity: Entity) -> bool {
+        if !self.is_alive(entity) {
+            return false;
+        }
+
         if let Some(location) = self.entity_allocator.delete_entity(entity) {
             // find entity's chunk
             let chunk = self

--- a/src/world.rs
+++ b/src/world.rs
@@ -823,6 +823,9 @@ impl World {
                 self.entity_allocator.set_location(entity.index(), location);
             }
         }
+
+        // Merge resources
+        self.resources.merge(world.resources);
     }
 
     fn find_archetype<T, C>(&self, tags: &mut T, components: &mut C) -> Option<usize>

--- a/src/world.rs
+++ b/src/world.rs
@@ -49,9 +49,7 @@ pub struct Universe {
 
 impl Universe {
     /// Creates a new `Universe`.
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 
     /// Creates a new `World` within this `Universe`.
     ///
@@ -80,9 +78,7 @@ impl Default for Universe {
 pub struct WorldId(usize);
 
 impl WorldId {
-    pub fn index(self) -> usize {
-        self.0
-    }
+    pub fn index(self) -> usize { self.0 }
 }
 
 /// Contains queryable collections of data associated with `Entity`s.
@@ -125,9 +121,7 @@ impl World {
     }
 
     #[inline]
-    pub fn command_buffer_size(&self) -> usize {
-        self.command_buffer_size
-    }
+    pub fn command_buffer_size(&self) -> usize { self.command_buffer_size }
 
     #[inline]
     pub fn set_command_buffer_size(&mut self, command_buffer_size: usize) {
@@ -163,18 +157,12 @@ impl World {
         self.storage_mut().subscribe(sender, filter);
     }
 
-    pub(crate) fn storage(&self) -> &Storage {
-        unsafe { &*self.storage.get() }
-    }
+    pub(crate) fn storage(&self) -> &Storage { unsafe { &*self.storage.get() } }
 
-    pub(crate) fn storage_mut(&mut self) -> &mut Storage {
-        unsafe { &mut *self.storage.get() }
-    }
+    pub(crate) fn storage_mut(&mut self) -> &mut Storage { unsafe { &mut *self.storage.get() } }
 
     /// Gets the unique ID of this world within its universe.
-    pub fn id(&self) -> WorldId {
-        self.id
-    }
+    pub fn id(&self) -> WorldId { self.id }
 
     /// Inserts new entities into the world.
     ///
@@ -689,9 +677,7 @@ impl World {
     }
 
     /// Determines if the given `Entity` is alive within this `World`.
-    pub fn is_alive(&self, entity: Entity) -> bool {
-        self.entity_allocator.is_alive(entity)
-    }
+    pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
 
     /// Iteratively defragments the world's internal memory.
     ///
@@ -859,9 +845,7 @@ impl World {
 }
 
 impl Default for World {
-    fn default() -> Self {
-        Self::new()
-    }
+    fn default() -> Self { Self::new() }
 }
 
 /// Describes the types of a set of components attached to an entity.
@@ -1238,9 +1222,7 @@ struct DynamicComponentLayout<'a> {
 impl<'a> ComponentLayout for DynamicComponentLayout<'a> {
     type Filter = Self;
 
-    fn get_filter(&mut self) -> &mut Self::Filter {
-        self
-    }
+    fn get_filter(&mut self) -> &mut Self::Filter { self }
 
     fn tailor_archetype(&self, archetype: &mut ArchetypeDescription) {
         // copy components from existing archetype into new
@@ -1298,9 +1280,7 @@ unsafe impl<'a> Sync for DynamicTagLayout<'a> {}
 impl<'a> TagLayout for DynamicTagLayout<'a> {
     type Filter = Self;
 
-    fn get_filter(&mut self) -> &mut Self::Filter {
-        self
-    }
+    fn get_filter(&mut self) -> &mut Self::Filter { self }
 
     fn tailor_archetype(&self, archetype: &mut ArchetypeDescription) {
         // copy tags from existing archetype into new
@@ -1324,9 +1304,7 @@ impl<'a> TagLayout for DynamicTagLayout<'a> {
 impl<'a, 'b> Filter<ArchetypeFilterData<'b>> for DynamicTagLayout<'a> {
     type Iter = SliceVecIter<'b, TagTypeId>;
 
-    fn collect(&self, source: ArchetypeFilterData<'b>) -> Self::Iter {
-        source.tag_types.iter()
-    }
+    fn collect(&self, source: ArchetypeFilterData<'b>) -> Self::Iter { source.tag_types.iter() }
 
     fn is_match(&self, item: &<Self::Iter as Iterator>::Item) -> Option<bool> {
         Some(

--- a/src/world.rs
+++ b/src/world.rs
@@ -956,7 +956,7 @@ mod tuple_impls {
         ( @COMPONENT_SOURCE $( $ty: ident => $id: ident ),* ) => {
             impl<UWU, $( $ty ),*> ComponentLayout for ComponentTupleSet<($( $ty, )*), UWU>
             where
-                UWU: Iterator<Item = ($( $ty, )*)>,
+                UWU: ExactSizeIterator + Iterator<Item = ($( $ty, )*)>,
                 $( $ty: Component ),*
             {
                 type Filter = ComponentTupleFilter<($( $ty, )*)>;
@@ -975,7 +975,7 @@ mod tuple_impls {
 
             impl<UWU, $( $ty ),*> ComponentSource for ComponentTupleSet<($( $ty, )*), UWU>
             where
-                UWU: Iterator<Item = ($( $ty, )*)>,
+                UWU: ExactSizeIterator + Iterator<Item = ($( $ty, )*)>,
                 $( $ty: Component ),*
             {
                 fn is_empty(&mut self) -> bool {
@@ -983,10 +983,7 @@ mod tuple_impls {
                 }
 
                 fn len(&self) -> usize {
-                    #[allow(dead_code, non_camel_case_types)]
-                    enum Idents { $($ty,)* __CountIdentsLast }
-                    const COUNT: usize = Idents::__CountIdentsLast as usize;
-                    COUNT
+                    self.iter.len()
                 }
 
                 fn write_entities(&mut self, provided_entities: &[Entity], chunk: &mut ComponentStorage) -> usize {

--- a/src/world.rs
+++ b/src/world.rs
@@ -393,7 +393,7 @@ impl World {
             .archetypes()
             .get(source_location.archetype())
             .unwrap();
-        let mut tags = source_archetype.tags().tag_set(source_location.chunk());
+        let mut tags = source_archetype.tags().tag_set(source_location.set());
         for type_id in remove_tags.iter() {
             tags.remove(*type_id);
         }
@@ -1446,7 +1446,7 @@ mod tests {
         let mut world = create();
 
         let entity = world.insert((), vec![()])[0];
-        world.add_component(entity, Pos(1., 2., 3.));
+        world.add_component(entity, Pos(1., 2., 3.)).unwrap();
 
         let components = vec![
             (Pos(1., 2., 3.), Rot(0.1, 0.2, 0.3)),
@@ -1457,7 +1457,7 @@ mod tests {
         world.insert_buffered(&entities, (), IntoComponentSource::into(components.clone()));
 
         for (i, e) in entities.iter().enumerate() {
-            world.add_component(*e, Scale(2., 2., 2.));
+            world.add_component(*e, Scale(2., 2., 2.)).unwrap();
             assert_eq!(
                 components.get(i).unwrap().0,
                 *world.get_component(*e).unwrap()
@@ -1659,7 +1659,7 @@ mod tests {
         let entities = world.insert((Static,), components.clone()).to_vec();
 
         for (i, e) in entities.iter().enumerate() {
-            world.add_component(*e, Scale(2., 2., 2.));
+            world.add_component(*e, Scale(2., 2., 2.)).unwrap();
             assert_eq!(
                 components.get(i).unwrap().0,
                 *world.get_component(*e).unwrap()
@@ -1758,12 +1758,14 @@ mod tests {
         }
         let mut world = create();
         let entity = world.insert((5u32,), vec![(3u32,)])[0];
-        world.add_component::<Transform>(
-            entity,
-            Transform {
-                translation: vec![0., 1., 2.],
-            },
-        );
+        world
+            .add_component::<Transform>(
+                entity,
+                Transform {
+                    translation: vec![0., 1., 2.],
+                },
+            )
+            .unwrap();
     }
 
     #[test]

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -263,7 +263,9 @@ fn mutate_add_component() {
     assert_eq!(3, query_without_scale.iter(&mut world).count());
     assert_eq!(0, query_with_scale.iter(&mut world).count());
 
-    world.add_component(*entities.get(1).unwrap(), Scale(0.5, 0.5, 0.5));
+    world
+        .add_component(*entities.get(1).unwrap(), Scale(0.5, 0.5, 0.5))
+        .unwrap();
 
     assert_eq!(3, query_without_scale.iter(&mut world).count());
     assert_eq!(1, query_with_scale.iter(&mut world).count());


### PR DESCRIPTION
This commit makes a few internals changes, but not much of a public API change. The aim of this PR is completing the CommandBuffer implementation to a working order. This current implementation does not consider inefficiencies in the implementation (a buffer copy, basically).

The command buffer implementation has been shifted, to taking N entities out of the world and keeping them resident to the buffer for usage. Every frame, the Scheduler now calls `resize` on the command buffer, having it take more entities if it needs. This means any given buffer can only create N entities any given frame. This is a logical limitation for the system, I believe.

This made some changes to the `World` object:
- Added a `command_buffer_size` parameter to `World`, defaulting to 64 via `World::DEFAULT_COMMAND_BUFFER_SIZE`. This configures how many entities a command buffer takes any given frame.
- Moved the actual inner workings of `insert` into `insert_impl`, `insert` is now just a wrapper for this. This was done because I have added `len` to `ComponentSource`, which allows to retrieve the length of the insert at compile time.
- Added `pub(crate) insert_buffered`, which allows us to perform an insert-like API call for already allocated entities. 
- Added `write_entities` to `ComponentSource`, to allow writing chunks for already-allocated entities
- `CommandBuffer` now requires `mut` on a few extra function calls.
- Adds `has_component` and `has_component_by_id` to World, allowing for component checks
- Adds `remove_components` and `add_components` to World, preventing multiple moves occurring when adding and removing multiple entities.

This PR is feature complete in that:
- Entity's can not be retrieved out of command buffers for creation and insertion.
- `CommandBuffer::create_entity` now works
- `CommandBuffer::insert` now actually behaves like `World::insert`, returning a `Vec` of entities which were inserted. 
- `EntityBuilder` now works, where `build` now takes a `CommandBuffer`, and creates an insert command for it.

This also contains the following fixes:
- Added `is_alive` checks to the beginning of `World::delete` and `World:add_component`, as it caused UB when a dead entity was passed to these functions.
