### PR TITLE
fix subtracting overflow in World::defrag

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -971,12 +971,13 @@ impl Chunkset {
         mut on_moved: F,
     ) -> bool {
         let slice = self.occupied_mut();
-        let mut first = 0;
-        let mut last = slice.len() - 1;
 
         if slice.is_empty() {
             return true;
         }
+
+        let mut first = 0;
+        let mut last = slice.len() - 1;
 
         trace!("Defragmenting chunkset");
 


### PR DESCRIPTION
Fixes #60 

Simply moving the `let mut last = slice.len() - 1;` a few lines down should do the trick given that slice cannot have a len of zero at that point due to the branching return.