### PR TITLE
Clone merge

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -789,10 +789,9 @@ impl ArchetypeData {
                     }
 
                     // Walk through each component type to copy the data from the source chunk to the destination chunk
-                    for src_type in other.description().components() {
+                    for (src_type, _) in other.description().components() {
                         // Look up what type we should transform the data into (can be the same type, meaning it should be cloned)
-                        let (dst_type, dst_type_meta) = clone_impl.map_component_type(src_type);
-                        let (src_type, src_type_meta) = src_type;
+                        let (dst_type, _) = clone_impl.map_component_type(*src_type);
 
                         // Create a writer that will insert the data into the destination chunk
                         let mut self_comp_storage = dst_components
@@ -817,8 +816,7 @@ impl ArchetypeData {
 
                             // Delegate the clone operation to the provided CloneImpl
                             clone_impl.clone(
-                                &src_type_meta,
-                                &dst_type_meta,
+                                *src_type,
                                 comp_src,
                                 comp_dst,
                                 entities_to_write,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -825,7 +825,7 @@ impl ArchetypeData {
                                 self_comp_storage.reserve_raw(entities_to_write).as_ptr();
 
                             // Delegate the clone operation to the provided CloneImpl
-                            clone_impl.clone(*src_type, comp_src, comp_dst, entities_to_write);
+                            clone_impl.clone(&dst_entities[src_entity_start_idx..src_entity_end_idx], *src_type, comp_src, comp_dst, entities_to_write);
 
                             // Component storages are dense (swap-removes are used to keep them from becoming fragmented.) This means
                             // the open slots in the chunk are at the end. We extended dst_entities all at once above so we can offset

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -757,7 +757,9 @@ impl ArchetypeData {
                     // we can use the mapping to respawn entities as needed using the new data.
 
                     // We know how many entities will be appended to this list
-                    dst_entities.reserve(dst_entities.len() + entities_to_write);
+                    dst_entities.reserve(entities_to_write);
+                    let dst_entity_start_idx = dst_entities.len();
+                    let dst_entity_end_idx = dst_entities.len() + entities_to_write;
 
                     for src_entity in &src_chunk.entities[src_entity_start_idx..src_entity_end_idx]
                     {
@@ -820,6 +822,8 @@ impl ArchetypeData {
                             let dst_data =
                                 dst_component_writer.reserve_raw(entities_to_write).as_ptr();
 
+                            let dst_entity_start_idx =
+
                             // Delegate the clone operation to the provided CloneImpl
                             clone_impl.clone_components(
                                 src_world,
@@ -828,7 +832,7 @@ impl ArchetypeData {
                                 dst_resources,
                                 *src_type,
                                 &src_chunk.entities[src_entity_start_idx..src_entity_end_idx],
-                                &dst_entities[src_entity_start_idx..src_entity_end_idx],
+                                &dst_entities[dst_entity_start_idx..dst_entity_end_idx],
                                 src_data,
                                 dst_data,
                                 entities_to_write,
@@ -839,6 +843,162 @@ impl ArchetypeData {
                 }
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn clone_merge_single<C: crate::world::CloneMergeImpl>(
+        &mut self,
+        src_world: &crate::world::World,
+        src_archetype: &ArchetypeData,
+        src_location: &EntityLocation,
+        dst_archetype_index: usize,
+        dst_entity_allocator: &mut crate::entity::EntityAllocator,
+        dst_resources: &crate::resource::Resources,
+        clone_impl: &C,
+        //replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        //result_mappings: &mut Option<&mut std::collections::HashMap<Entity, Entity>>,
+    ) {
+        // Iterate all the chunk sets within the source archetype
+        let src_tags = &src_archetype.tags;
+        let src_chunk_set_index = src_location.set();
+        let src_chunk_set = &src_archetype.chunk_sets[src_chunk_set_index];
+        //for (src_chunk_set_index, src_chunk_set) in src_archetype.chunk_sets.iter().enumerate() {
+            // Find or create the chunk set that matches the source chunk set
+            let dst_chunk_set_index = self.find_chunk_set_by_tags(&src_tags, src_chunk_set_index);
+            let dst_chunk_set_index = dst_chunk_set_index.unwrap_or_else(|| {
+                self.alloc_chunk_set(|self_tags| {
+                    for (type_id, other_tags) in src_tags.0.iter() {
+                        unsafe {
+                            let (src, _, _) = other_tags.data_raw();
+                            let dst = self_tags.get_mut(*type_id).unwrap().alloc_ptr();
+                            other_tags.element().clone(src.as_ptr(), dst);
+                        }
+                    }
+                })
+            });
+
+            // Iterate all the chunks within the source chunk set
+            let src_chunk_idx = src_location.chunk();
+            let src_chunk = &src_chunk_set.chunks[src_chunk_idx];
+            //for (_src_chunk_idx, src_chunk) in src_chunk_set.chunks.iter().enumerate() {
+                // Copy the data from source to destination. Continuously find or create chunks as
+                // needed until we've copied all the data
+                //let mut entities_remaining = src_chunk.len();
+                //while entities_remaining > 0 {
+                    // Get or allocate a chunk.. since we could be transforming to a larger component size, it's possible
+                    // that even a brand-new, empty chunk won't be large enough to hold everything in the chunk we are copying from
+                    let dst_free_chunk_index =
+                        self.get_free_chunk(dst_chunk_set_index, 1);
+                    let dst_chunk_set = &mut self.chunk_sets[dst_chunk_set_index];
+                    let dst_chunk = &mut dst_chunk_set.chunks[dst_free_chunk_index];
+
+                    // Determine how many entities we will write
+                    let entities_to_write = 1;
+
+                    // Prepare to write to the chunk storage
+                    let mut writer = dst_chunk.writer();
+                    let (dst_entities, dst_components) = writer.get();
+                    let dst_components = unsafe { &mut *dst_components.get() };
+
+                    // Find the region of memory we will be reading from in the source chunk
+                    let src_entity_start_idx = src_location.component();
+                    let src_entity_end_idx = src_entity_start_idx + 1;
+
+                    // Copy all the entities to the destination chunk. The normal case is that we simply allocate
+                    // new entities.
+                    //
+                    // We also allow end-user to specify a HashMap<Entity, Entity>. The key is an Entity from
+                    // the source chunk and the value is an Entity from the destination chunk. Rather than appending
+                    // data to the destination chunk, we will *replace* the data, according to the mapping. This
+                    // is specifically intended for use with hot-reloading data. When some source data is changed,
+                    // we can use the mapping to respawn entities as needed using the new data.
+
+                    // We know how many entities will be appended to this list
+                    dst_entities.reserve(entities_to_write);
+                    let dst_entity_start_idx = dst_entities.len();
+                    let dst_entity_end_idx = dst_entities.len() + entities_to_write;
+
+                    for src_entity in &src_chunk.entities[src_entity_start_idx..src_entity_end_idx]
+                        {
+                            // The location of the next entity
+                            let location = EntityLocation::new(
+                                dst_archetype_index,
+                                dst_chunk_set_index,
+                                dst_free_chunk_index,
+                                dst_entities.len(),
+                            );
+
+//                            // Determine if there is an entity we will be replacing
+//                            let dst_entity = replace_mappings.and_then(|x| x.get(src_entity));
+//
+//                            // Determine the Entity to use for this element
+//                            let dst_entity = if let Some(dst_entity) = dst_entity {
+//                                // We are replacing data
+//                                // Verify that the entity is alive.. this checks the index and version of the entity
+//                                //TODO: This check may not be needed in release mode since World::clone_merge checks it
+//                                assert!(dst_entity_allocator.is_alive(*dst_entity));
+//                                *dst_entity
+//                            } else {
+//                                // We are appending data, allocate a new entity
+//                                dst_entity_allocator.create_entity()
+//                            };
+                            let dst_entity = dst_entity_allocator.create_entity();
+
+                            dst_entity_allocator.set_location(dst_entity.index(), location);
+                            dst_entities.push(dst_entity);
+
+//                            if let Some(result_mappings) = result_mappings {
+//                                result_mappings.insert(*src_entity, dst_entity);
+//                            }
+                        }
+
+                    // Walk through each component type to copy the data from the source chunk to the destination chunk
+                    for (src_type, _) in src_archetype.description().components() {
+                        // Look up what type we should transform the data into (can be the same type, meaning it should be cloned)
+                        let (dst_type, _) = clone_impl.map_component_type(*src_type);
+
+                        // Create a writer that will insert the data into the destination chunk
+                        let mut dst_component_writer = dst_components
+                            .get_mut(dst_type)
+                            .expect("ComponentResourceSet missing in clone_merge")
+                            .writer();
+
+                        // Find the data in the source chunk
+                        let src_component_storage = src_chunk
+                            .components(*src_type)
+                            .expect("ComponentResourceSet missing in clone_merge");
+                        let (src_component_chunk_data, src_element_size, _) =
+                            src_component_storage.data_raw();
+
+                        // Now copy the data
+                        unsafe {
+                            // offset to the first entity we want to copy from the source chunk
+                            let src_data = src_component_chunk_data
+                                .add(src_element_size * src_entity_start_idx);
+
+                            // allocate the space we need in the destination chunk
+                            let dst_data =
+                                dst_component_writer.reserve_raw(entities_to_write).as_ptr();
+
+                            // Delegate the clone operation to the provided CloneImpl
+                            clone_impl.clone_components(
+                                src_world,
+                                src_chunk,
+                                src_entity_start_idx..src_entity_end_idx,
+                                dst_resources,
+                                *src_type,
+                                &src_chunk.entities[src_entity_start_idx..src_entity_end_idx],
+                                &dst_entities[dst_entity_start_idx..dst_entity_end_idx],
+                                src_data,
+                                dst_data,
+                                entities_to_write,
+                            );
+                        }
+                    }
+                    //entities_remaining -= entities_to_write;
+                //}
+            //}
+        //}
     }
 
     pub(crate) fn enumerate_entities<'a>(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -822,6 +822,8 @@ impl ArchetypeData {
                             // Delegate the clone operation to the provided CloneImpl
                             clone_impl.clone_components(
                                 src_world,
+                                src_chunk,
+                                src_entity_start_idx..src_entity_end_idx,
                                 dst_resources,
                                 *src_type,
                                 &src_chunk.entities[src_entity_start_idx..src_entity_end_idx],

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -692,6 +692,7 @@ impl ArchetypeData {
         self.tags.validate(self.chunk_sets.len());
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn clone_merge<C: crate::world::CloneMergeImpl>(
         &mut self,
         src_world: &crate::world::World,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -697,8 +697,9 @@ impl ArchetypeData {
         other: &ArchetypeData,
         archetype_index: usize,
         entity_allocator: &mut crate::entity::EntityAllocator,
-        entity_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        resources: &crate::resource::Resources,
         clone_impl: &C,
+        entity_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
     ) {
         println!(
             "clone_merge on {:?} {:?}",
@@ -825,7 +826,14 @@ impl ArchetypeData {
                                 self_comp_storage.reserve_raw(entities_to_write).as_ptr();
 
                             // Delegate the clone operation to the provided CloneImpl
-                            clone_impl.clone(&dst_entities[src_entity_start_idx..src_entity_end_idx], *src_type, comp_src, comp_dst, entities_to_write);
+                            clone_impl.clone_components(
+                                resources,
+                                *src_type,
+                                &dst_entities[src_entity_start_idx..src_entity_end_idx],
+                                comp_src,
+                                comp_dst,
+                                entities_to_write,
+                            );
 
                             // Component storages are dense (swap-removes are used to keep them from becoming fragmented.) This means
                             // the open slots in the chunk are at the end. We extended dst_entities all at once above so we can offset

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -699,7 +699,8 @@ impl ArchetypeData {
         entity_allocator: &mut crate::entity::EntityAllocator,
         resources: &crate::resource::Resources,
         clone_impl: &C,
-        entity_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        result_mappings: &mut Option<&mut std::collections::HashMap<Entity, Entity>>,
     ) {
         println!(
             "clone_merge on {:?} {:?}",
@@ -772,7 +773,7 @@ impl ArchetypeData {
                         );
 
                         // Determine if there is an entity we will be replacing
-                        let dst_entity = entity_mappings
+                        let dst_entity = replace_mappings
                             .and_then(|x| x.get(&other_chunk.entities[src_entity_idx]));
 
                         let entity = if let Some(dst_entity) = dst_entity {
@@ -797,6 +798,10 @@ impl ArchetypeData {
 
                         entity_allocator.set_location(entity.index(), location);
                         dst_entities.push(entity);
+
+                        if let Some(result_mappings) = result_mappings {
+                            result_mappings.insert(other_chunk.entities[src_entity_idx], entity);
+                        }
                     }
 
                     // Walk through each component type to copy the data from the source chunk to the destination chunk

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -757,9 +757,7 @@ impl ArchetypeData {
                     // we can use the mapping to respawn entities as needed using the new data.
 
                     // We know how many entities will be appended to this list
-                    dst_entities.reserve(entities_to_write);
-                    let dst_entity_start_idx = dst_entities.len();
-                    let dst_entity_end_idx = dst_entities.len() + entities_to_write;
+                    dst_entities.reserve(dst_entities.len() + entities_to_write);
 
                     for src_entity in &src_chunk.entities[src_entity_start_idx..src_entity_end_idx]
                     {
@@ -822,8 +820,6 @@ impl ArchetypeData {
                             let dst_data =
                                 dst_component_writer.reserve_raw(entities_to_write).as_ptr();
 
-                            let dst_entity_start_idx =
-
                             // Delegate the clone operation to the provided CloneImpl
                             clone_impl.clone_components(
                                 src_world,
@@ -832,7 +828,7 @@ impl ArchetypeData {
                                 dst_resources,
                                 *src_type,
                                 &src_chunk.entities[src_entity_start_idx..src_entity_end_idx],
-                                &dst_entities[dst_entity_start_idx..dst_entity_end_idx],
+                                &dst_entities[src_entity_start_idx..src_entity_end_idx],
                                 src_data,
                                 dst_data,
                                 entities_to_write,
@@ -843,162 +839,6 @@ impl ArchetypeData {
                 }
             }
         }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn clone_merge_single<C: crate::world::CloneMergeImpl>(
-        &mut self,
-        src_world: &crate::world::World,
-        src_archetype: &ArchetypeData,
-        src_location: &EntityLocation,
-        dst_archetype_index: usize,
-        dst_entity_allocator: &mut crate::entity::EntityAllocator,
-        dst_resources: &crate::resource::Resources,
-        clone_impl: &C,
-        //replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
-        //result_mappings: &mut Option<&mut std::collections::HashMap<Entity, Entity>>,
-    ) {
-        // Iterate all the chunk sets within the source archetype
-        let src_tags = &src_archetype.tags;
-        let src_chunk_set_index = src_location.set();
-        let src_chunk_set = &src_archetype.chunk_sets[src_chunk_set_index];
-        //for (src_chunk_set_index, src_chunk_set) in src_archetype.chunk_sets.iter().enumerate() {
-            // Find or create the chunk set that matches the source chunk set
-            let dst_chunk_set_index = self.find_chunk_set_by_tags(&src_tags, src_chunk_set_index);
-            let dst_chunk_set_index = dst_chunk_set_index.unwrap_or_else(|| {
-                self.alloc_chunk_set(|self_tags| {
-                    for (type_id, other_tags) in src_tags.0.iter() {
-                        unsafe {
-                            let (src, _, _) = other_tags.data_raw();
-                            let dst = self_tags.get_mut(*type_id).unwrap().alloc_ptr();
-                            other_tags.element().clone(src.as_ptr(), dst);
-                        }
-                    }
-                })
-            });
-
-            // Iterate all the chunks within the source chunk set
-            let src_chunk_idx = src_location.chunk();
-            let src_chunk = &src_chunk_set.chunks[src_chunk_idx];
-            //for (_src_chunk_idx, src_chunk) in src_chunk_set.chunks.iter().enumerate() {
-                // Copy the data from source to destination. Continuously find or create chunks as
-                // needed until we've copied all the data
-                //let mut entities_remaining = src_chunk.len();
-                //while entities_remaining > 0 {
-                    // Get or allocate a chunk.. since we could be transforming to a larger component size, it's possible
-                    // that even a brand-new, empty chunk won't be large enough to hold everything in the chunk we are copying from
-                    let dst_free_chunk_index =
-                        self.get_free_chunk(dst_chunk_set_index, 1);
-                    let dst_chunk_set = &mut self.chunk_sets[dst_chunk_set_index];
-                    let dst_chunk = &mut dst_chunk_set.chunks[dst_free_chunk_index];
-
-                    // Determine how many entities we will write
-                    let entities_to_write = 1;
-
-                    // Prepare to write to the chunk storage
-                    let mut writer = dst_chunk.writer();
-                    let (dst_entities, dst_components) = writer.get();
-                    let dst_components = unsafe { &mut *dst_components.get() };
-
-                    // Find the region of memory we will be reading from in the source chunk
-                    let src_entity_start_idx = src_location.component();
-                    let src_entity_end_idx = src_entity_start_idx + 1;
-
-                    // Copy all the entities to the destination chunk. The normal case is that we simply allocate
-                    // new entities.
-                    //
-                    // We also allow end-user to specify a HashMap<Entity, Entity>. The key is an Entity from
-                    // the source chunk and the value is an Entity from the destination chunk. Rather than appending
-                    // data to the destination chunk, we will *replace* the data, according to the mapping. This
-                    // is specifically intended for use with hot-reloading data. When some source data is changed,
-                    // we can use the mapping to respawn entities as needed using the new data.
-
-                    // We know how many entities will be appended to this list
-                    dst_entities.reserve(entities_to_write);
-                    let dst_entity_start_idx = dst_entities.len();
-                    let dst_entity_end_idx = dst_entities.len() + entities_to_write;
-
-                    for src_entity in &src_chunk.entities[src_entity_start_idx..src_entity_end_idx]
-                        {
-                            // The location of the next entity
-                            let location = EntityLocation::new(
-                                dst_archetype_index,
-                                dst_chunk_set_index,
-                                dst_free_chunk_index,
-                                dst_entities.len(),
-                            );
-
-//                            // Determine if there is an entity we will be replacing
-//                            let dst_entity = replace_mappings.and_then(|x| x.get(src_entity));
-//
-//                            // Determine the Entity to use for this element
-//                            let dst_entity = if let Some(dst_entity) = dst_entity {
-//                                // We are replacing data
-//                                // Verify that the entity is alive.. this checks the index and version of the entity
-//                                //TODO: This check may not be needed in release mode since World::clone_merge checks it
-//                                assert!(dst_entity_allocator.is_alive(*dst_entity));
-//                                *dst_entity
-//                            } else {
-//                                // We are appending data, allocate a new entity
-//                                dst_entity_allocator.create_entity()
-//                            };
-                            let dst_entity = dst_entity_allocator.create_entity();
-
-                            dst_entity_allocator.set_location(dst_entity.index(), location);
-                            dst_entities.push(dst_entity);
-
-//                            if let Some(result_mappings) = result_mappings {
-//                                result_mappings.insert(*src_entity, dst_entity);
-//                            }
-                        }
-
-                    // Walk through each component type to copy the data from the source chunk to the destination chunk
-                    for (src_type, _) in src_archetype.description().components() {
-                        // Look up what type we should transform the data into (can be the same type, meaning it should be cloned)
-                        let (dst_type, _) = clone_impl.map_component_type(*src_type);
-
-                        // Create a writer that will insert the data into the destination chunk
-                        let mut dst_component_writer = dst_components
-                            .get_mut(dst_type)
-                            .expect("ComponentResourceSet missing in clone_merge")
-                            .writer();
-
-                        // Find the data in the source chunk
-                        let src_component_storage = src_chunk
-                            .components(*src_type)
-                            .expect("ComponentResourceSet missing in clone_merge");
-                        let (src_component_chunk_data, src_element_size, _) =
-                            src_component_storage.data_raw();
-
-                        // Now copy the data
-                        unsafe {
-                            // offset to the first entity we want to copy from the source chunk
-                            let src_data = src_component_chunk_data
-                                .add(src_element_size * src_entity_start_idx);
-
-                            // allocate the space we need in the destination chunk
-                            let dst_data =
-                                dst_component_writer.reserve_raw(entities_to_write).as_ptr();
-
-                            // Delegate the clone operation to the provided CloneImpl
-                            clone_impl.clone_components(
-                                src_world,
-                                src_chunk,
-                                src_entity_start_idx..src_entity_end_idx,
-                                dst_resources,
-                                *src_type,
-                                &src_chunk.entities[src_entity_start_idx..src_entity_end_idx],
-                                &dst_entities[dst_entity_start_idx..dst_entity_end_idx],
-                                src_data,
-                                dst_data,
-                                entities_to_write,
-                            );
-                        }
-                    }
-                    //entities_remaining -= entities_to_write;
-                //}
-            //}
-        //}
     }
 
     pub(crate) fn enumerate_entities<'a>(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -751,7 +751,7 @@ impl ArchetypeData {
                     let free_chunk_index = self.get_free_chunk(self_set_index, entities_remaining);
                     let target_chunk_set = &mut self.chunk_sets[self_set_index];
                     let chunk = &mut target_chunk_set.chunks[free_chunk_index];
-                    let entities_to_write = std::cmp::min(entities_remaining, chunk.capacity());
+                    let entities_to_write = std::cmp::min(entities_remaining, chunk.capacity() - chunk.len());
                     let mut writer = chunk.writer();
                     let (dst_entities, dst_components) = writer.get();
                     let dst_components = unsafe { &mut *dst_components.get() };
@@ -776,7 +776,7 @@ impl ArchetypeData {
 
                             let comp_dst = self_comp_storage.reserve_raw(entities_to_write).as_ptr();
                             c.clone(&src_type.1, &dst_type_meta, comp_src, comp_dst, entities_to_write);
-                            println!("cloned {} entities for type {:?} to type {:?} from chunk {} to chunk {}", entities_to_write, src_type.0, dst_type, other_chunk_idx, free_chunk_index );
+                            println!("cloned {} entities for type {:?} to type {:?} from chunk {} to chunk {}, starting at src idx {} and writing to dst idx {}", entities_to_write, src_type.0, dst_type, other_chunk_idx, free_chunk_index, entity_start_idx, dst_entities.len() - entities_to_write);
                         }
                     }
                     entities_remaining -= entities_to_write;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -717,7 +717,12 @@ impl ArchetypeData {
         self.tags.validate(self.chunk_sets.len());
     }
 
-    pub(crate) fn clone_merge<C: crate::world::CloneImpl>(&mut self, other: &ArchetypeData, c: &C) {
+    pub(crate) fn clone_merge<C: crate::world::CloneImpl>(
+        &mut self,
+        other: &ArchetypeData,
+        entity_allocator: &mut crate::entity::EntityAllocator,
+        clone_impl: &C,
+    ) {
         println!(
             "clone_merge on {:?} {:?}",
             self.desc.tag_names, self.desc.component_names
@@ -748,35 +753,92 @@ impl ArchetypeData {
 
                 let mut entities_remaining = other_chunk.len();
                 while entities_remaining > 0 {
+                    // Get or allocate a chunk.. since we could be transforming to a larger component size, it's possible
+                    // that even a brand-new, empty chunk won't be large enough to hold everything in the chunk we are copying from
                     let free_chunk_index = self.get_free_chunk(self_set_index, entities_remaining);
                     let target_chunk_set = &mut self.chunk_sets[self_set_index];
                     let chunk = &mut target_chunk_set.chunks[free_chunk_index];
-                    let entities_to_write = std::cmp::min(entities_remaining, chunk.capacity() - chunk.len());
+
+                    // Determine how many entities we will write
+                    let entities_to_write =
+                        std::cmp::min(entities_remaining, chunk.capacity() - chunk.len());
+
+                    // Prepare to write to the chunk storage
                     let mut writer = chunk.writer();
                     let (dst_entities, dst_components) = writer.get();
                     let dst_components = unsafe { &mut *dst_components.get() };
-                    let entity_start_idx = other_chunk.len() - entities_remaining;
-                    dst_entities.extend_from_slice(
-                        &other_chunk.entities[entity_start_idx..entities_to_write],
-                    );
-                    // TODO set entity location and REMOVE THE ENTITY ID IF IT ALREADY EXISTS??
+
+                    // Find the region of memory we will be reading from in the source chunk
+                    let src_entity_start_idx = other_chunk.len() - entities_remaining;
+                    let src_entity_end_idx = src_entity_start_idx + entities_to_write;
+
+                    // Copy all the entities to the destination chunk.
+                    // TODO: This is dangerous because these entities could already exist elsewhere.
+                    // - First pass: allocate new entities
+                    // - Second pass: Allow end-user to specify a HashMap<Entity, Entity>. For each entity we copy,
+                    //   if it exists as a key within the map, then we insert the corresponding value into the
+                    //   destination chunk instead. We would also want to delete all entities that exist as a
+                    //   matching *value* - The rationale of this behavior is to support hot-reload of data, where
+                    //   we want to respawn entities using new data.
+
+                    // For each entity we are copying over from the source chunk, allocate a new entity
+                    dst_entities.reserve(dst_entities.len() + entities_to_write);
+                    for _ in 0..entities_to_write {
+                        dst_entities.push(entity_allocator.create_entity());
+                        println!("Allocated entity {:?}", dst_entities.last().unwrap());
+                    }
+
+                    // Walk through each component type to copy the data from the source chunk to the destination chunk
                     for src_type in other.description().components() {
-                        let (dst_type, dst_type_meta) = c.map_component_type(src_type);
+                        // Look up what type we should transform the data into (can be the same type, meaning it should be cloned)
+                        let (dst_type, dst_type_meta) = clone_impl.map_component_type(src_type);
+                        let (src_type, src_type_meta) = src_type;
+
+                        // Create a writer that will insert the data into the destination chunk
                         let mut self_comp_storage = dst_components
                             .get_mut(dst_type)
                             .expect("ComponentResourceSet missing in clone_merge")
                             .writer();
+
+                        // Find the data in the source chunk
                         let other_comp_storage = other_chunk
-                            .components(src_type.0)
+                            .components(*src_type)
                             .expect("ComponentResourceSet missing in clone_merge");
                         let (comp_src, src_element_size, _) = other_comp_storage.data_raw();
-                        unsafe {
-                            // offset to the first entity we want to copy
-                            let comp_src = comp_src.add(src_element_size * entity_start_idx);
 
-                            let comp_dst = self_comp_storage.reserve_raw(entities_to_write).as_ptr();
-                            c.clone(&src_type.1, &dst_type_meta, comp_src, comp_dst, entities_to_write);
-                            println!("cloned {} entities for type {:?} to type {:?} from chunk {} to chunk {}, starting at src idx {} and writing to dst idx {}", entities_to_write, src_type.0, dst_type, other_chunk_idx, free_chunk_index, entity_start_idx, dst_entities.len() - entities_to_write);
+                        // Now copy the data
+                        unsafe {
+                            // offset to the first entity we want to copy from the source chunk
+                            let comp_src = comp_src.add(src_element_size * src_entity_start_idx);
+
+                            // allocate the space we need in the destination chunk
+                            let comp_dst =
+                                self_comp_storage.reserve_raw(entities_to_write).as_ptr();
+
+                            // Delegate the clone operation to the provided CloneImpl
+                            clone_impl.clone(
+                                &src_type_meta,
+                                &dst_type_meta,
+                                comp_src,
+                                comp_dst,
+                                entities_to_write,
+                            );
+
+                            // Component storages are dense (swap-removes are used to keep them from becoming fragmented.) This means
+                            // the open slots in the chunk are at the end. We extended dst_entities all at once above so we can offset
+                            // it by entities_to_write
+                            let dst_entity_start_idx = dst_entities.len() - entities_to_write;
+
+                            println!(
+                                "cloned {} entities for type {:?} to type {:?} from chunk {} to chunk {}, starting at src idx {} and writing to dst idx {}",
+                                entities_to_write,
+                                src_type.0,
+                                dst_type,
+                                other_chunk_idx,
+                                free_chunk_index,
+                                src_entity_start_idx,
+                                dst_entity_start_idx
+                            );
                         }
                     }
                     entities_remaining -= entities_to_write;

--- a/src/world.rs
+++ b/src/world.rs
@@ -875,6 +875,7 @@ pub trait CloneImpl {
 
     fn clone(
         &self,
+        entities: &[Entity],
         src_type: ComponentTypeId,
         src_data: *const u8,
         dst_data: *mut u8,

--- a/src/world.rs
+++ b/src/world.rs
@@ -816,102 +816,6 @@ impl World {
         }
     }
 
-    pub fn clone_merge_single<C: CloneMergeImpl>(
-        &mut self,
-        src_world: &World,
-        src_entity: Entity,
-        clone_impl: &C,
-        //replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
-        //mut result_mappings: Option<&mut std::collections::HashMap<Entity, Entity>>,
-    ) {
-        let span = span!(Level::INFO, "CloneMerging worlds", source = src_world.id().0, destination = ?self.id());
-        let _guard = span.enter();
-
-        let src_storage = unsafe { &(*src_world.storage.get()) };
-        let dst_storage = unsafe { &mut (*self.storage.get()) };
-
-        // Erase all entities that are referred to by value. The code following will update the location
-        // of all these entities to point to new, valid locations
-//        if let Some(replace_mappings) = replace_mappings {
-//            // First check that all the keys exist in the source world. We're assuming the source
-//            // data will be available later to replace the data we're about to delete
-//            for k in replace_mappings.keys() {
-//                if !src_world.entity_allocator.is_alive(*k) {
-//                    panic!("clone_merge assumes all entity_mapping keys exist in the source world");
-//                }
-//            }
-//
-//            // Delete all the data associated with keys in replace_mappings. This leaves the
-//            // associated entities in a dangling state, but we'll fix this later when we copy the
-//            // data over
-//            for v in replace_mappings.values() {
-//                if self.entity_allocator.is_alive(*v) {
-//                    let location = self
-//                        .entity_allocator
-//                        .get_location(v.index())
-//                        .expect("Failed to get location of live entity");
-//                    self.delete_location(location);
-//                } else {
-//                    panic!("clone_merge assumes all entity_mapping values exist in the destination world");
-//                }
-//            }
-//        }
-
-        if !src_world.entity_allocator.is_alive(src_entity) {
-            panic!("src_entity not alive");
-        }
-
-        let src_location = src_world.entity_allocator.get_location(src_entity.index()).unwrap();
-        let src_archetype = &src_storage.archetypes()[src_location.archetype()];
-
-
-        // Iterate all archetypes in the src world
-        //for src_archetype in src_storage.archetypes() {
-            let archetype_data = ArchetypeFilterData {
-                component_types: self.storage().component_types(),
-                tag_types: self.storage().tag_types(),
-            };
-
-            // Build the archetype that we will write into. The caller of this function provides an
-            // impl to do the clone, optionally transforming components from one type to another
-            let mut dst_archetype = ArchetypeDescription::default();
-            for (from_type_id, _from_meta) in src_archetype.description().components() {
-                let (into_type_id, into_meta) = clone_impl.map_component_type(*from_type_id);
-                dst_archetype.register_component_raw(into_type_id, into_meta);
-            }
-
-            // Find or create the archetype in the destination world
-            let matches = dst_archetype
-                .matches(archetype_data)
-                .matching_indices()
-                .next();
-
-            // If it doesn't exist, allocate it
-            let dst_archetype_index = if let Some(arch_index) = matches {
-                arch_index
-            } else {
-                dst_storage.alloc_archetype(dst_archetype).0
-            };
-
-            // Do the clone_merge for this archetype
-            dst_storage
-                .archetypes_mut()
-                .get_mut(dst_archetype_index)
-                .unwrap()
-                .clone_merge_single(
-                    &src_world,
-                    src_archetype,
-                    &src_location,
-                    dst_archetype_index,
-                    &mut self.entity_allocator,
-                    &self.resources,
-                    clone_impl,
-                    //replace_mappings,
-                    //&mut result_mappings,
-                );
-        //}
-    }
-
     fn find_archetype<T, C>(&self, tags: &mut T, components: &mut C) -> Option<usize>
     where
         T: for<'a> Filter<ArchetypeFilterData<'a>>,
@@ -1034,8 +938,6 @@ pub trait CloneMergeImpl {
         dst_data: *mut u8,
         num_components: usize,
     );
-
-    //TODO: should replace_mappings and result_mappings be owned by the impl?
 }
 
 /// Describes the types of a set of components attached to an entity.

--- a/src/world.rs
+++ b/src/world.rs
@@ -612,6 +612,31 @@ impl World {
     /// Determines if the given `Entity` is alive within this `World`.
     pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
 
+    /// Returns the entity's component types, if the entity exists.
+    pub fn entity_component_types(&self, entity: Entity) -> Option<&[(ComponentTypeId, ComponentMeta)]> {
+        if !self.is_alive(entity) {
+            return None
+        }
+        let location = self
+            .entity_allocator
+            .get_location(entity.index());
+        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        archetype.map(|archetype| archetype.description().components())
+    }
+
+    /// Returns the entity's tag types, if the entity exists.
+    pub fn entity_tag_types(&self, entity: Entity) -> Option<&[(TagTypeId, TagMeta)]> {
+        if !self.is_alive(entity) {
+            return None
+        }
+        let location = self
+            .entity_allocator
+            .get_location(entity.index());
+        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        archetype.map(|archetype| archetype.description().tags())
+        
+    }
+
     /// Iteratively defragments the world's internal memory.
     ///
     /// This compacts entities into fewer more continuous chunks.

--- a/src/world.rs
+++ b/src/world.rs
@@ -692,7 +692,8 @@ impl World {
         &mut self,
         world: &World,
         clone_impl: &C,
-        entity_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        mut result_mappings: Option<&mut std::collections::HashMap<Entity, Entity>>,
     ) {
         let span = span!(Level::INFO, "CloneMerging worlds", source = world.id().0, destination = ?self.id());
         let _guard = span.enter();
@@ -702,15 +703,15 @@ impl World {
 
         // Erase all entities that are referred to by value. The code following will update the location
         // of all these entities to point to new, valid locations
-        if let Some(entity_mappings) = entity_mappings {
+        if let Some(replace_mappings) = replace_mappings {
             //TODO: Compile this out in release?
-            for (k, _) in entity_mappings {
+            for (k, _) in replace_mappings {
                 if !world.entity_allocator.is_alive(*k) {
                     panic!("clone_merge assumes all entity_mapping keys exist in the source world");
                 }
             }
 
-            for (_, v) in entity_mappings {
+            for (_, v) in replace_mappings {
                 if self.entity_allocator.is_alive(*v) {
                     let location = self
                         .entity_allocator
@@ -774,7 +775,8 @@ impl World {
                     &mut self.entity_allocator,
                     &mut self.resources,
                     clone_impl,
-                    entity_mappings,
+                    replace_mappings,
+                    &mut result_mappings
                 );
         }
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -816,6 +816,102 @@ impl World {
         }
     }
 
+    pub fn clone_merge_single<C: CloneMergeImpl>(
+        &mut self,
+        src_world: &World,
+        src_entity: Entity,
+        clone_impl: &C,
+        //replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+        //mut result_mappings: Option<&mut std::collections::HashMap<Entity, Entity>>,
+    ) {
+        let span = span!(Level::INFO, "CloneMerging worlds", source = src_world.id().0, destination = ?self.id());
+        let _guard = span.enter();
+
+        let src_storage = unsafe { &(*src_world.storage.get()) };
+        let dst_storage = unsafe { &mut (*self.storage.get()) };
+
+        // Erase all entities that are referred to by value. The code following will update the location
+        // of all these entities to point to new, valid locations
+//        if let Some(replace_mappings) = replace_mappings {
+//            // First check that all the keys exist in the source world. We're assuming the source
+//            // data will be available later to replace the data we're about to delete
+//            for k in replace_mappings.keys() {
+//                if !src_world.entity_allocator.is_alive(*k) {
+//                    panic!("clone_merge assumes all entity_mapping keys exist in the source world");
+//                }
+//            }
+//
+//            // Delete all the data associated with keys in replace_mappings. This leaves the
+//            // associated entities in a dangling state, but we'll fix this later when we copy the
+//            // data over
+//            for v in replace_mappings.values() {
+//                if self.entity_allocator.is_alive(*v) {
+//                    let location = self
+//                        .entity_allocator
+//                        .get_location(v.index())
+//                        .expect("Failed to get location of live entity");
+//                    self.delete_location(location);
+//                } else {
+//                    panic!("clone_merge assumes all entity_mapping values exist in the destination world");
+//                }
+//            }
+//        }
+
+        if !src_world.entity_allocator.is_alive(src_entity) {
+            panic!("src_entity not alive");
+        }
+
+        let src_location = src_world.entity_allocator.get_location(src_entity.index()).unwrap();
+        let src_archetype = &src_storage.archetypes()[src_location.archetype()];
+
+
+        // Iterate all archetypes in the src world
+        //for src_archetype in src_storage.archetypes() {
+            let archetype_data = ArchetypeFilterData {
+                component_types: self.storage().component_types(),
+                tag_types: self.storage().tag_types(),
+            };
+
+            // Build the archetype that we will write into. The caller of this function provides an
+            // impl to do the clone, optionally transforming components from one type to another
+            let mut dst_archetype = ArchetypeDescription::default();
+            for (from_type_id, _from_meta) in src_archetype.description().components() {
+                let (into_type_id, into_meta) = clone_impl.map_component_type(*from_type_id);
+                dst_archetype.register_component_raw(into_type_id, into_meta);
+            }
+
+            // Find or create the archetype in the destination world
+            let matches = dst_archetype
+                .matches(archetype_data)
+                .matching_indices()
+                .next();
+
+            // If it doesn't exist, allocate it
+            let dst_archetype_index = if let Some(arch_index) = matches {
+                arch_index
+            } else {
+                dst_storage.alloc_archetype(dst_archetype).0
+            };
+
+            // Do the clone_merge for this archetype
+            dst_storage
+                .archetypes_mut()
+                .get_mut(dst_archetype_index)
+                .unwrap()
+                .clone_merge_single(
+                    &src_world,
+                    src_archetype,
+                    &src_location,
+                    dst_archetype_index,
+                    &mut self.entity_allocator,
+                    &self.resources,
+                    clone_impl,
+                    //replace_mappings,
+                    //&mut result_mappings,
+                );
+        //}
+    }
+
     fn find_archetype<T, C>(&self, tags: &mut T, components: &mut C) -> Option<usize>
     where
         T: for<'a> Filter<ArchetypeFilterData<'a>>,
@@ -938,6 +1034,8 @@ pub trait CloneMergeImpl {
         dst_data: *mut u8,
         num_components: usize,
     );
+
+    //TODO: should replace_mappings and result_mappings be owned by the impl?
 }
 
 /// Describes the types of a set of components attached to an entity.

--- a/src/world.rs
+++ b/src/world.rs
@@ -900,6 +900,8 @@ pub trait CloneMergeImpl {
     fn clone_components(
         &self,
         src_world: &World,
+        src_component_storage: &ComponentStorage,
+        src_component_storage_indexes: core::ops::Range<usize>,
         dst_resources: &Resources,
         src_type: ComponentTypeId,
         src_entities: &[Entity],

--- a/src/world.rs
+++ b/src/world.rs
@@ -686,7 +686,7 @@ impl World {
         }
     }
 
-    pub fn clone_merge<C: CloneImpl>(&mut self, world: &World, c: &C) {
+    pub fn clone_merge<C: CloneImpl>(&mut self, world: &World, clone_impl: &C) {
         let span = span!(Level::INFO, "CloneMerging worlds", source = world.id().0, destination = ?self.id());
         let _guard = span.enter();
 
@@ -703,14 +703,23 @@ impl World {
             // See if we need to transform from one type into another
             let mut new_archetype = ArchetypeDescription::default();
             for component_type in old_archetype.description().components() {
-                let (type_id, meta) = c.map_component_type(component_type);
+                let (type_id, meta) = clone_impl.map_component_type(component_type);
                 new_archetype.register_component_raw(type_id, meta);
 
-                println!("map {:?} of size {} to {:?} of size {}", component_type.0, component_type.1.size(), type_id, meta.size());
+                println!(
+                    "map {:?} of size {} to {:?} of size {}",
+                    component_type.0,
+                    component_type.1.size(),
+                    type_id,
+                    meta.size()
+                );
             }
 
             // Find or create the archetype in the new world
-            let matches = new_archetype.matches(archetype_data).matching_indices().next();
+            let matches = new_archetype
+                .matches(archetype_data)
+                .matching_indices()
+                .next();
             let arch_index = if let Some(arch_index) = matches {
                 println!("found archetype");
                 arch_index
@@ -719,59 +728,12 @@ impl World {
                 new_storage.alloc_archetype(new_archetype).0
             };
 
-            // Need to allocate entities and pass them in here? Or pass down the entity allocator?
-            // self.entity_allocator.create_entity()
-
             new_storage
                 .archetypes_mut()
                 .get_mut(arch_index)
                 .unwrap()
-                .clone_merge(old_archetype, c);
+                .clone_merge(old_archetype, &mut self.entity_allocator, clone_impl);
         }
-
-
-
-        // for each archetype, for each chunk... allocate archetypes/chunks
-/*
-        let old_storage = unsafe { &(*world.storage.get()) };
-        let new_storage = unsafe { &mut (*self.storage.get()) };
-        for old_archetype in old_storage.archetypes() {
-            let new_archetype = new_storage.archetypes().iter().filter(|new_archetype| old_archetype.description() == new_archetype.description()).nth(0);
-
-            let new_archetype = if let Some(new_archetype) = new_archetype {
-                new_archetype
-            } else {
-                let index = new_storage.alloc_archetype(old_archetype.clone());
-            };
-
-
-//            let archetype_data = ArchetypeFilterData {
-//                component_types: self.storage().component_types(),
-//                tag_types: self.storage().tag_types(),
-//            };
-
-            //old_archetype.description().is_match()
-
-            //self.find_or_create_archetype()
-
-//            let new_archetype = old_archetype.description().matches(archetype_data)
-//                .zip(old_archetype.description().matches(archetype_data))
-//                .enumerate()
-//                .take(self.storage().archetypes().len())
-//                .filter(|(_, (a, b))| *a && *b)
-//                .map(|(i, _)| i)
-//                .next();
-
-            //self.storage.get()
-            //old_archetype.description().
-
-//            for old_chunkset in old_archetype.chunksets() {
-//
-//            }
-        }
-        */
-
-
     }
 
     fn find_archetype<T, C>(&self, tags: &mut T, components: &mut C) -> Option<usize>
@@ -864,7 +826,10 @@ impl World {
 }
 
 pub trait CloneImpl {
-    fn map_component_type(&self, component_type: &(ComponentTypeId, ComponentMeta)) -> (ComponentTypeId, ComponentMeta);
+    fn map_component_type(
+        &self,
+        component_type: &(ComponentTypeId, ComponentMeta),
+    ) -> (ComponentTypeId, ComponentMeta);
 
     fn clone(
         &self,
@@ -872,7 +837,7 @@ pub trait CloneImpl {
         dst_type: &ComponentMeta,
         src_data: *const u8,
         dst_data: *mut u8,
-        num_components: usize
+        num_components: usize,
     );
 }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -620,7 +620,7 @@ impl World {
         let location = self
             .entity_allocator
             .get_location(entity.index());
-        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).unwrap_or(None);
         archetype.map(|archetype| archetype.description().components())
     }
 
@@ -632,7 +632,7 @@ impl World {
         let location = self
             .entity_allocator
             .get_location(entity.index());
-        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).unwrap_or(None);
         archetype.map(|archetype| archetype.description().tags())
         
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -688,29 +688,48 @@ impl World {
         }
     }
 
-    pub fn clone_merge<C: CloneImpl>(
+    /// This will *copy* the data from `src_world` into this world. The logic to do the copy is
+    /// delegated to the `clone_impl` provided by the user. In addition to simple copying, it's also
+    /// possible to transform from one type to another. This is useful for cases where you want to
+    /// read from serializable data (like a physics shape definition) and construct something that
+    /// isn't serializable (like a handle to a physics body)
+    ///
+    /// By default, all entities in the new world will be assigned a new Entity. `result_mappings`
+    /// (if not None) will be populated with the old/new Entities, which allows for mapping data
+    /// between the old and new world.
+    ///
+    /// If you want to replace existing entities (for example to hot-reload data from a file,)
+    /// populate `replace_mappings`. For every entry in this map, the key must exist in the source
+    /// world and the value must exist in the destination world. All entities in the destination
+    /// world referenced by this map will be deleted, and the entities copied over will be assigned
+    /// the same entity. If these constraints are not met, this function will panic.
+    pub fn clone_merge<C: CloneMergeImpl>(
         &mut self,
-        world: &World,
+        src_world: &World,
         clone_impl: &C,
         replace_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
         mut result_mappings: Option<&mut std::collections::HashMap<Entity, Entity>>,
     ) {
-        let span = span!(Level::INFO, "CloneMerging worlds", source = world.id().0, destination = ?self.id());
+        let span = span!(Level::INFO, "CloneMerging worlds", source = src_world.id().0, destination = ?self.id());
         let _guard = span.enter();
 
-        let old_storage = unsafe { &(*world.storage.get()) };
-        let new_storage = unsafe { &mut (*self.storage.get()) };
+        let src_storage = unsafe { &(*src_world.storage.get()) };
+        let dst_storage = unsafe { &mut (*self.storage.get()) };
 
         // Erase all entities that are referred to by value. The code following will update the location
         // of all these entities to point to new, valid locations
         if let Some(replace_mappings) = replace_mappings {
-            //TODO: Compile this out in release?
+            // First check that all the keys exist in the source world. We're assuming the source
+            // data will be available later to replace the data we're about to delete
             for (k, _) in replace_mappings {
-                if !world.entity_allocator.is_alive(*k) {
+                if !src_world.entity_allocator.is_alive(*k) {
                     panic!("clone_merge assumes all entity_mapping keys exist in the source world");
                 }
             }
 
+            // Delete all the data associated with keys in replace_mappings. This leaves the
+            // associated entities in a dangling state, but we'll fix this later when we copy the
+            // data over
             for (_, v) in replace_mappings {
                 if self.entity_allocator.is_alive(*v) {
                     let location = self
@@ -718,16 +737,14 @@ impl World {
                         .get_location(v.index())
                         .expect("Failed to get location of live entity");
                     self.delete_location(location);
-
-                    println!("Delete the data for entity {:?} at {:?}", v, location)
                 } else {
                     panic!("clone_merge assumes all entity_mapping values exist in the destination world");
                 }
             }
         }
 
-        // Iterate all archetypes in the old world
-        for old_archetype in old_storage.archetypes() {
+        // Iterate all archetypes in the src world
+        for src_archetype in src_storage.archetypes() {
             let archetype_data = ArchetypeFilterData {
                 component_types: self.storage().component_types(),
                 tag_types: self.storage().tag_types(),
@@ -735,48 +752,39 @@ impl World {
 
             // Build the archetype that we will write into. The caller of this function provides an
             // impl to do the clone, optionally transforming components from one type to another
-            let mut new_archetype = ArchetypeDescription::default();
-            for (from_type_id, from_meta) in old_archetype.description().components() {
+            let mut dst_archetype = ArchetypeDescription::default();
+            for (from_type_id, _from_meta) in src_archetype.description().components() {
                 let (into_type_id, into_meta) = clone_impl.map_component_type(*from_type_id);
-                new_archetype.register_component_raw(into_type_id, into_meta);
-
-                println!(
-                    "map {:?} of size {} to {:?} of size {}",
-                    from_type_id,
-                    from_meta.size(),
-                    into_type_id,
-                    into_meta.size()
-                );
+                dst_archetype.register_component_raw(into_type_id, into_meta);
             }
 
-            // Find or create the archetype in the new world
-            let matches = new_archetype
+            // Find or create the archetype in the destination world
+            let matches = dst_archetype
                 .matches(archetype_data)
                 .matching_indices()
                 .next();
 
             // If it doesn't exist, allocate it
-            let arch_index = if let Some(arch_index) = matches {
-                println!("found archetype");
+            let dst_archetype_index = if let Some(arch_index) = matches {
                 arch_index
             } else {
-                println!("creating archetype");
-                new_storage.alloc_archetype(new_archetype).0
+                dst_storage.alloc_archetype(dst_archetype).0
             };
 
             // Do the clone_merge for this archetype
-            new_storage
+            dst_storage
                 .archetypes_mut()
-                .get_mut(arch_index)
+                .get_mut(dst_archetype_index)
                 .unwrap()
                 .clone_merge(
-                    old_archetype,
-                    arch_index,
+                    &src_world,
+                    src_archetype,
+                    dst_archetype_index,
                     &mut self.entity_allocator,
                     &mut self.resources,
                     clone_impl,
                     replace_mappings,
-                    &mut result_mappings
+                    &mut result_mappings,
                 );
         }
     }
@@ -870,25 +878,36 @@ impl World {
     }
 }
 
-pub trait CloneImpl {
+impl Default for World {
+    fn default() -> Self { Self::new() }
+}
+
+/// Describes how to handle a clone_merge. Allows the user to transform components from one type
+/// to another and provide their own implementation for cloning/transforming
+pub trait CloneMergeImpl {
+    /// When a component of the provided `component_type` is encountered, we will transfer data
+    /// from it into the returned component type. For a basic clone implementation, this function
+    /// should return the same type as was passed into it
     fn map_component_type(
         &self,
         component_type: ComponentTypeId,
     ) -> (ComponentTypeId, ComponentMeta);
 
+    /// When called, the implementation should copy the data from src_data to dst_data. The
+    /// src_world and src_entities are provided so that other components on the same Entity can
+    /// be looked up. The dst_resources are provided so that any required side effects to resources
+    /// (like registering a physics body into a physics engine) can be implemented.
     fn clone_components(
         &self,
-        resources: &Resources,
+        src_world: &World,
+        dst_resources: &Resources,
         src_type: ComponentTypeId,
-        entities: &[Entity],
+        src_entities: &[Entity],
+        dst_entities: &[Entity],
         src_data: *const u8,
         dst_data: *mut u8,
         num_components: usize,
     );
-}
-
-impl Default for World {
-    fn default() -> Self { Self::new() }
 }
 
 /// Describes the types of a set of components attached to an entity.

--- a/src/world.rs
+++ b/src/world.rs
@@ -686,6 +686,94 @@ impl World {
         }
     }
 
+    pub fn clone_merge<C: CloneImpl>(&mut self, world: &World, c: &C) {
+        let span = span!(Level::INFO, "CloneMerging worlds", source = world.id().0, destination = ?self.id());
+        let _guard = span.enter();
+
+        let old_storage = unsafe { &(*world.storage.get()) };
+        let new_storage = unsafe { &mut (*self.storage.get()) };
+
+        // Iterate all archetypes in the old world
+        for old_archetype in old_storage.archetypes() {
+            let archetype_data = ArchetypeFilterData {
+                component_types: self.storage().component_types(),
+                tag_types: self.storage().tag_types(),
+            };
+
+            // See if we need to transform from one type into another
+            let mut new_archetype = ArchetypeDescription::default();
+            for component_type in old_archetype.description().components() {
+                let (type_id, meta) = c.map_component_type(component_type);
+                new_archetype.register_component_raw(type_id, meta);
+
+                println!("map {:?} of size {} to {:?} of size {}", component_type.0, component_type.1.size(), type_id, meta.size());
+            }
+
+            // Find or create the archetype in the new world
+            let matches = new_archetype.matches(archetype_data).matching_indices().next();
+            let arch_index = if let Some(arch_index) = matches {
+                println!("found archetype");
+                arch_index
+            } else {
+                println!("creating archetype");
+                new_storage.alloc_archetype(new_archetype).0
+            };
+
+            // Need to allocate entities and pass them in here? Or pass down the entity allocator?
+            // self.entity_allocator.create_entity()
+
+            new_storage
+                .archetypes_mut()
+                .get_mut(arch_index)
+                .unwrap()
+                .clone_merge(old_archetype, c);
+        }
+
+
+
+        // for each archetype, for each chunk... allocate archetypes/chunks
+/*
+        let old_storage = unsafe { &(*world.storage.get()) };
+        let new_storage = unsafe { &mut (*self.storage.get()) };
+        for old_archetype in old_storage.archetypes() {
+            let new_archetype = new_storage.archetypes().iter().filter(|new_archetype| old_archetype.description() == new_archetype.description()).nth(0);
+
+            let new_archetype = if let Some(new_archetype) = new_archetype {
+                new_archetype
+            } else {
+                let index = new_storage.alloc_archetype(old_archetype.clone());
+            };
+
+
+//            let archetype_data = ArchetypeFilterData {
+//                component_types: self.storage().component_types(),
+//                tag_types: self.storage().tag_types(),
+//            };
+
+            //old_archetype.description().is_match()
+
+            //self.find_or_create_archetype()
+
+//            let new_archetype = old_archetype.description().matches(archetype_data)
+//                .zip(old_archetype.description().matches(archetype_data))
+//                .enumerate()
+//                .take(self.storage().archetypes().len())
+//                .filter(|(_, (a, b))| *a && *b)
+//                .map(|(i, _)| i)
+//                .next();
+
+            //self.storage.get()
+            //old_archetype.description().
+
+//            for old_chunkset in old_archetype.chunksets() {
+//
+//            }
+        }
+        */
+
+
+    }
+
     fn find_archetype<T, C>(&self, tags: &mut T, components: &mut C) -> Option<usize>
     where
         T: for<'a> Filter<ArchetypeFilterData<'a>>,
@@ -773,6 +861,19 @@ impl World {
             self.create_chunk_set(archetype, tags)
         }
     }
+}
+
+pub trait CloneImpl {
+    fn map_component_type(&self, component_type: &(ComponentTypeId, ComponentMeta)) -> (ComponentTypeId, ComponentMeta);
+
+    fn clone(
+        &self,
+        src_type: &ComponentMeta,
+        dst_type: &ComponentMeta,
+        src_data: *const u8,
+        dst_data: *mut u8,
+        num_components: usize
+    );
 }
 
 impl Default for World {

--- a/src/world.rs
+++ b/src/world.rs
@@ -700,18 +700,19 @@ impl World {
                 tag_types: self.storage().tag_types(),
             };
 
-            // See if we need to transform from one type into another
+            // Build the archetype that we will write into. The caller of this function provides an
+            // impl to do the clone, optionally transforming components from one type to another
             let mut new_archetype = ArchetypeDescription::default();
-            for component_type in old_archetype.description().components() {
-                let (type_id, meta) = clone_impl.map_component_type(component_type);
-                new_archetype.register_component_raw(type_id, meta);
+            for (from_type_id, from_meta) in old_archetype.description().components() {
+                let (into_type_id, into_meta) = clone_impl.map_component_type(*from_type_id);
+                new_archetype.register_component_raw(into_type_id, into_meta);
 
                 println!(
                     "map {:?} of size {} to {:?} of size {}",
-                    component_type.0,
-                    component_type.1.size(),
-                    type_id,
-                    meta.size()
+                    from_type_id,
+                    from_meta.size(),
+                    into_type_id,
+                    into_meta.size()
                 );
             }
 
@@ -720,6 +721,8 @@ impl World {
                 .matches(archetype_data)
                 .matching_indices()
                 .next();
+
+            // If it doesn't exist, allocate it
             let arch_index = if let Some(arch_index) = matches {
                 println!("found archetype");
                 arch_index
@@ -728,6 +731,7 @@ impl World {
                 new_storage.alloc_archetype(new_archetype).0
             };
 
+            // Do the clone_merge for this archetype
             new_storage
                 .archetypes_mut()
                 .get_mut(arch_index)
@@ -828,13 +832,12 @@ impl World {
 pub trait CloneImpl {
     fn map_component_type(
         &self,
-        component_type: &(ComponentTypeId, ComponentMeta),
+        component_type: ComponentTypeId,
     ) -> (ComponentTypeId, ComponentMeta);
 
     fn clone(
         &self,
-        src_type: &ComponentMeta,
-        dst_type: &ComponentMeta,
+        src_type: ComponentTypeId,
         src_data: *const u8,
         dst_data: *mut u8,
         num_components: usize,

--- a/src/world.rs
+++ b/src/world.rs
@@ -772,8 +772,9 @@ impl World {
                     old_archetype,
                     arch_index,
                     &mut self.entity_allocator,
-                    entity_mappings,
+                    &mut self.resources,
                     clone_impl,
+                    entity_mappings,
                 );
         }
     }
@@ -873,10 +874,11 @@ pub trait CloneImpl {
         component_type: ComponentTypeId,
     ) -> (ComponentTypeId, ComponentMeta);
 
-    fn clone(
+    fn clone_components(
         &self,
-        entities: &[Entity],
+        resources: &Resources,
         src_type: ComponentTypeId,
+        entities: &[Entity],
         src_data: *const u8,
         dst_data: *mut u8,
         num_components: usize,

--- a/src/world.rs
+++ b/src/world.rs
@@ -613,28 +613,30 @@ impl World {
     pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
 
     /// Returns the entity's component types, if the entity exists.
-    pub fn entity_component_types(&self, entity: Entity) -> Option<&[(ComponentTypeId, ComponentMeta)]> {
+    pub fn entity_component_types(
+        &self,
+        entity: Entity,
+    ) -> Option<&[(ComponentTypeId, ComponentMeta)]> {
         if !self.is_alive(entity) {
-            return None
+            return None;
         }
-        let location = self
-            .entity_allocator
-            .get_location(entity.index());
-        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).unwrap_or(None);
+        let location = self.entity_allocator.get_location(entity.index());
+        let archetype = location
+            .map(|location| self.storage().archetypes().get(location.archetype()))
+            .unwrap_or(None);
         archetype.map(|archetype| archetype.description().components())
     }
 
     /// Returns the entity's tag types, if the entity exists.
     pub fn entity_tag_types(&self, entity: Entity) -> Option<&[(TagTypeId, TagMeta)]> {
         if !self.is_alive(entity) {
-            return None
+            return None;
         }
-        let location = self
-            .entity_allocator
-            .get_location(entity.index());
-        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).unwrap_or(None);
+        let location = self.entity_allocator.get_location(entity.index());
+        let archetype = location
+            .map(|location| self.storage().archetypes().get(location.archetype()))
+            .unwrap_or(None);
         archetype.map(|archetype| archetype.description().tags())
-        
     }
 
     /// Iteratively defragments the world's internal memory.
@@ -746,7 +748,7 @@ impl World {
         if let Some(replace_mappings) = replace_mappings {
             // First check that all the keys exist in the source world. We're assuming the source
             // data will be available later to replace the data we're about to delete
-            for (k, _) in replace_mappings {
+            for k in replace_mappings.keys() {
                 if !src_world.entity_allocator.is_alive(*k) {
                     panic!("clone_merge assumes all entity_mapping keys exist in the source world");
                 }
@@ -755,7 +757,7 @@ impl World {
             // Delete all the data associated with keys in replace_mappings. This leaves the
             // associated entities in a dangling state, but we'll fix this later when we copy the
             // data over
-            for (_, v) in replace_mappings {
+            for v in replace_mappings.values() {
                 if self.entity_allocator.is_alive(*v) {
                     let location = self
                         .entity_allocator
@@ -806,7 +808,7 @@ impl World {
                     src_archetype,
                     dst_archetype_index,
                     &mut self.entity_allocator,
-                    &mut self.resources,
+                    &self.resources,
                     clone_impl,
                     replace_mappings,
                     &mut result_mappings,
@@ -922,6 +924,7 @@ pub trait CloneMergeImpl {
     /// src_world and src_entities are provided so that other components on the same Entity can
     /// be looked up. The dst_resources are provided so that any required side effects to resources
     /// (like registering a physics body into a physics engine) can be implemented.
+    #[allow(clippy::too_many_arguments)]
     fn clone_components(
         &self,
         src_world: &World,

--- a/src/world.rs
+++ b/src/world.rs
@@ -243,30 +243,32 @@ impl World {
     /// Returns `true` if the entity was deleted; else `false`.
     pub fn delete(&mut self, entity: Entity) -> bool {
         if let Some(location) = self.entity_allocator.delete_entity(entity) {
-            // find entity's chunk
-            let chunk = self
-                .storage_mut()
-                .archetypes_mut()
-                .get_mut(location.archetype())
-                .unwrap()
-                .chunksets_mut()
-                .get_mut(location.set())
-                .unwrap()
-                .get_mut(location.chunk())
-                .unwrap();
-
-            // swap remove with last entity in chunk
-            if let Some(swapped) = chunk.swap_remove(location.component(), true) {
-                // record swapped entity's new location
-                self.entity_allocator
-                    .set_location(swapped.index(), location);
-            }
-
+            self.delete_location(location);
             trace!(world = self.id().0, ?entity, "Deleted entity");
-
             true
         } else {
             false
+        }
+    }
+
+    fn delete_location(&mut self, location: EntityLocation) {
+        // find entity's chunk
+        let chunk = self
+            .storage_mut()
+            .archetypes_mut()
+            .get_mut(location.archetype())
+            .unwrap()
+            .chunksets_mut()
+            .get_mut(location.set())
+            .unwrap()
+            .get_mut(location.chunk())
+            .unwrap();
+
+        // swap remove with last entity in chunk
+        if let Some(swapped) = chunk.swap_remove(location.component(), true) {
+            // record swapped entity's new location
+            self.entity_allocator
+                .set_location(swapped.index(), location);
         }
     }
 
@@ -686,12 +688,42 @@ impl World {
         }
     }
 
-    pub fn clone_merge<C: CloneImpl>(&mut self, world: &World, clone_impl: &C) {
+    pub fn clone_merge<C: CloneImpl>(
+        &mut self,
+        world: &World,
+        clone_impl: &C,
+        entity_mappings: Option<&std::collections::HashMap<Entity, Entity>>,
+    ) {
         let span = span!(Level::INFO, "CloneMerging worlds", source = world.id().0, destination = ?self.id());
         let _guard = span.enter();
 
         let old_storage = unsafe { &(*world.storage.get()) };
         let new_storage = unsafe { &mut (*self.storage.get()) };
+
+        // Erase all entities that are referred to by value. The code following will update the location
+        // of all these entities to point to new, valid locations
+        if let Some(entity_mappings) = entity_mappings {
+            //TODO: Compile this out in release?
+            for (k, _) in entity_mappings {
+                if !world.entity_allocator.is_alive(*k) {
+                    panic!("clone_merge assumes all entity_mapping keys exist in the source world");
+                }
+            }
+
+            for (_, v) in entity_mappings {
+                if self.entity_allocator.is_alive(*v) {
+                    let location = self
+                        .entity_allocator
+                        .get_location(v.index())
+                        .expect("Failed to get location of live entity");
+                    self.delete_location(location);
+
+                    println!("Delete the data for entity {:?} at {:?}", v, location)
+                } else {
+                    panic!("clone_merge assumes all entity_mapping values exist in the destination world");
+                }
+            }
+        }
 
         // Iterate all archetypes in the old world
         for old_archetype in old_storage.archetypes() {
@@ -736,7 +768,13 @@ impl World {
                 .archetypes_mut()
                 .get_mut(arch_index)
                 .unwrap()
-                .clone_merge(old_archetype, &mut self.entity_allocator, clone_impl);
+                .clone_merge(
+                    old_archetype,
+                    arch_index,
+                    &mut self.entity_allocator,
+                    entity_mappings,
+                    clone_impl,
+                );
         }
     }
 


### PR DESCRIPTION
This implements `clone_merge`: a copying `merge` that lets the user choose how the copy is made. It also supports transforming one component type to another during the merge operation, where the user defines the transformation.

`clone_merge` will allocate new entity IDs in the dst world by default, but can be fed with an entity mapping to specify the mappings of IDs from src to dst world. A `result_mapping` can be supplied if the user wishes to know about the final mappings of src to dst world entities, which takes into account newly allocated entities as well as any replaced entities.