### PR TITLE
Fix CommandBuffer::insert failing improperly

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -526,13 +526,10 @@ impl CommandBuffer {
         C: 'static + IntoComponentSource,
     {
         let components = components.into();
-        if components.len() > self.free_list.len() {
-            return Err(CommandError::EntityBlockFull);
-        }
 
         let mut entities = Vec::with_capacity(components.len());
         for _ in 0..components.len() {
-            entities.push(self.free_list.pop().ok_or(CommandError::EntityBlockFull)?);
+            entities.push(self.create_entity()?);
         }
 
         self.commands


### PR DESCRIPTION
Fixes incorrect checking of entity freelist in `CommandBuffer`. Insert would fail with an `EntityBlockFull` message, instead of refilling if able. 

This changes it to use create_entity to properly refill and not error.

This was left in by accident by me before shifting to the mutex-based entity allocator.