### PR TITLE
Add support iterating across all entities

### DIFF
--- a/legion_core/src/storage.rs
+++ b/legion_core/src/storage.rs
@@ -746,7 +746,26 @@ impl ArchetypeData {
         self.tags.validate(self.chunk_sets.len());
     }
 
-    pub(crate) fn enumerate_entities<'a>(
+    /// Iterate all entities in existence by iterating across archetypes, chunk sets, and chunks
+    pub(crate) fn iter_entities<'a>(&'a self) -> impl Iterator<Item = Entity> + 'a {
+        self.chunk_sets
+            .iter()
+            .enumerate()
+            .flat_map(move |(_set_index, set)| {
+                set.chunks
+                    .iter()
+                    .enumerate()
+                    .flat_map(move |(_chunk_index, chunk)| {
+                        chunk
+                            .entities()
+                            .iter()
+                            .enumerate()
+                            .map(move |(_entity_index, entity)| *entity)
+                    })
+            })
+    }
+
+    pub(crate) fn iter_entity_locations<'a>(
         &'a self,
         archetype_index: ArchetypeIndex,
     ) -> impl Iterator<Item = (Entity, EntityLocation)> + 'a {

--- a/legion_core/src/storage.rs
+++ b/legion_core/src/storage.rs
@@ -748,21 +748,11 @@ impl ArchetypeData {
 
     /// Iterate all entities in existence by iterating across archetypes, chunk sets, and chunks
     pub(crate) fn iter_entities<'a>(&'a self) -> impl Iterator<Item = Entity> + 'a {
-        self.chunk_sets
-            .iter()
-            .enumerate()
-            .flat_map(move |(_set_index, set)| {
-                set.chunks
-                    .iter()
-                    .enumerate()
-                    .flat_map(move |(_chunk_index, chunk)| {
-                        chunk
-                            .entities()
-                            .iter()
-                            .enumerate()
-                            .map(move |(_entity_index, entity)| *entity)
-                    })
-            })
+        self.chunk_sets.iter().flat_map(move |set| {
+            set.chunks
+                .iter()
+                .flat_map(move |chunk| chunk.entities().iter().map(|e| *e))
+        })
     }
 
     pub(crate) fn iter_entity_locations<'a>(

--- a/legion_core/src/storage.rs
+++ b/legion_core/src/storage.rs
@@ -751,7 +751,7 @@ impl ArchetypeData {
         self.chunk_sets.iter().flat_map(move |set| {
             set.chunks
                 .iter()
-                .flat_map(move |chunk| chunk.entities().iter().map(|e| *e))
+                .flat_map(move |chunk| chunk.entities().iter().copied())
         })
     }
 

--- a/legion_core/src/world.rs
+++ b/legion_core/src/world.rs
@@ -188,6 +188,16 @@ impl World {
         }
     }
 
+    /// Iterate all entities in existence. Internally this iterates archetypes instead of
+    /// entity allocators because the data structures contains a list of free entities instead
+    /// of allocated entities
+    pub fn iter_entities<'a>(&'a self) -> impl Iterator<Item = Entity> + 'a {
+        self.storage()
+            .archetypes()
+            .iter()
+            .flat_map(|archetype_data| archetype_data.iter_entities().map(|entity| entity))
+    }
+
     /// Inserts new entities into the world. This insertion method should be preferred, as it performs
     /// no movement of components for inserting multiple entities and components.
     ///
@@ -788,7 +798,7 @@ impl World {
 
             // update entity locations
             let archetype = &unsafe { &*self.storage.get() }.archetypes()[target_archetype];
-            for (entity, location) in archetype.enumerate_entities(target_archetype) {
+            for (entity, location) in archetype.iter_entity_locations(target_archetype) {
                 self.entity_locations.set(entity, location);
             }
         }

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -1,4 +1,5 @@
 use legion::prelude::*;
+use std::collections::HashSet;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct Pos(f32, f32, f32);
@@ -442,4 +443,33 @@ fn lots_of_deletes() {
         let mut world = universe.create_world();
         world.insert(shared, components).to_vec();
     }
+}
+
+#[test]
+fn iter_entities() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    let shared = (Model(5),);
+    let components = vec![
+        (Pos(1., 2., 3.), Rot(0.1, 0.2, 0.3)),
+        (Pos(4., 5., 6.), Rot(0.4, 0.5, 0.6)),
+        (Pos(4., 5., 6.), Rot(0.4, 0.5, 0.6)),
+    ];
+
+    // Insert the data and store resulting entities in a HashSet
+    let mut entities = HashSet::new();
+    for entity in world.insert(shared, components) {
+        entities.insert(*entity);
+    }
+
+    // Verify that all entities in iter_entities() are included
+    for entity in world.iter_entities() {
+        assert!(entities.remove(&entity));
+    }
+
+    // Verify that no extra entities are included
+    assert!(entities.is_empty());
 }


### PR DESCRIPTION
This is implemented by iterating component storage to find live entities. I'm using this for comparing two worlds and detecting what has been added between the two worlds.

The function enumerate_entities already existed. I considered renaming it to enumerate_entity_locations but that seemed a bit long. Also, I see more usages of iter_* than enumerate_* in standard library, so maybe it's a tiny bit more idiomatic, maybe?

I don't have a strong opinion about the naming though. Happy to change it to whatever you prefer!