### PR TITLE
Fire RemoveEntity events when a ComponentStorage is dropped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { version = "0.8", features = ["v4"] }
 tracing = "0.1"
 itertools = "0.8"
 rayon = "1.2"
+crossbeam-channel = "0.4.0"
 
 [[bench]]
 name = "benchmarks"

--- a/legion_core/src/storage.rs
+++ b/legion_core/src/storage.rs
@@ -1488,6 +1488,12 @@ impl Drop for ComponentStorage {
                 }
             }
 
+            for e in &self.entities {
+                self.subscribers.send(Event::EntityRemoved(*e, self.id()));
+            }
+
+            self.update_count_gauge();
+
             // free the chunk's memory
             unsafe {
                 std::alloc::dealloc(ptr.as_ptr(), self.component_layout);

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -1,4 +1,5 @@
 use legion::prelude::*;
+use std::collections::HashSet;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct Pos(f32, f32, f32);
@@ -376,6 +377,42 @@ fn mutate_change_tag_minimum_test() {
     tracing::trace!("CHANGED\n");
 
     assert_eq!(*world.get_tag::<Model>(entities[0]).unwrap(), Model(3));
+}
+
+#[test]
+fn delete_entities_on_drop() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    let (tx, rx) = crossbeam_channel::unbounded::<legion::event::Event>();
+
+    let shared = (Model(5),);
+    let components = vec![(Pos(1., 2., 3.), Rot(0.1, 0.2, 0.3))];
+
+    // Insert the data and store resulting entities in a HashSet
+    let mut entities = HashSet::new();
+    for entity in world.insert(shared, components) {
+        entities.insert(*entity);
+    }
+
+    world.subscribe(tx, legion::filter::filter_fns::any());
+
+    //ManuallyDrop::drop(&mut world);
+    std::mem::drop(world);
+
+    for e in rx.try_recv() {
+        match e {
+            legion::event::Event::EntityRemoved(entity, _chunk_id) => {
+                assert!(entities.remove(&entity));
+            }
+            _ => {}
+        }
+    }
+
+    // Verify that no extra entities are included
+    assert!(entities.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Not sure if you consider it a bug that the event doesn't fire if a world is dropped. I have another PR that adds support for deleting all entities. This change would ensure events fire in that case too.