### PR TITLE
Add support for removing all entity data

### DIFF
--- a/legion_core/src/entity.rs
+++ b/legion_core/src/entity.rs
@@ -292,14 +292,7 @@ impl EntityAllocator {
             .unwrap_or(false)
     }
 
-    pub(crate) fn merge(&self, other: EntityAllocator) {
-        assert!(Arc::ptr_eq(&self.allocator, &other.allocator));
-        self.blocks.write().append(&mut *other.blocks.write());
-    }
-}
-
-impl Drop for EntityAllocator {
-    fn drop(&mut self) {
+    pub(crate) fn delete_all_entities(&self) {
         for block in self.blocks.write().blocks.drain(..) {
             if let Some(mut block) = block {
                 // If any entity in the block is in an allocated state, clear
@@ -318,6 +311,15 @@ impl Drop for EntityAllocator {
             }
         }
     }
+
+    pub(crate) fn merge(&self, other: EntityAllocator) {
+        assert!(Arc::ptr_eq(&self.allocator, &other.allocator));
+        self.blocks.write().append(&mut *other.blocks.write());
+    }
+}
+
+impl Drop for EntityAllocator {
+    fn drop(&mut self) { self.delete_all_entities(); }
 }
 
 pub struct CreateEntityIter<'a> {

--- a/legion_core/src/storage.rs
+++ b/legion_core/src/storage.rs
@@ -663,6 +663,13 @@ impl ArchetypeData {
         }
     }
 
+    pub(crate) fn delete_all(&mut self) {
+        for set in &mut self.chunk_sets {
+            // Clearing the chunk will Drop all the data
+            set.chunks.clear();
+        }
+    }
+
     pub(crate) fn subscribe(&mut self, subscriber: Subscriber) {
         self.subscribers.push(subscriber.clone());
 

--- a/legion_core/src/world.rs
+++ b/legion_core/src/world.rs
@@ -301,6 +301,15 @@ impl World {
         }
     }
 
+    /// Delete all entity data. This leaves subscriptions and the command buffer intact.
+    pub fn delete_all(&mut self) {
+        for archetype in self.storage_mut().archetypes_mut() {
+            archetype.delete_all();
+        }
+
+        self.entity_allocator.delete_all_entities();
+    }
+
     fn find_chunk_with_delta(
         &mut self,
         source_location: EntityLocation,

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -136,6 +136,45 @@ fn delete() {
 }
 
 #[test]
+fn delete_all() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    let shared = (Static, Model(5));
+    let components = vec![
+        (Pos(1., 2., 3.), Rot(0.1, 0.2, 0.3)),
+        (Pos(4., 5., 6.), Rot(0.4, 0.5, 0.6)),
+    ];
+
+    let mut entities: Vec<Entity> = Vec::new();
+    for e in world.insert(shared, components) {
+        entities.push(*e);
+    }
+
+    // Check that the entity allocator knows about the entities
+    for e in entities.iter() {
+        assert_eq!(true, world.is_alive(*e));
+    }
+
+    // Check that the entities are in storage
+    let query = <(Read<Pos>, Read<Rot>)>::query();
+    assert_eq!(2, query.iter(&world).count());
+
+    world.delete_all();
+
+    // Check that the entity allocator no longer knows about the entities
+    for e in entities.iter() {
+        assert_eq!(false, world.is_alive(*e));
+    }
+
+    // Check that the entities are removed from storage
+    let query = <(Read<Pos>, Read<Rot>)>::query();
+    assert_eq!(0, query.iter(&world).count());
+}
+
+#[test]
 fn delete_last() {
     let _ = tracing_subscriber::fmt::try_init();
 


### PR DESCRIPTION
This change deletes all entities from the entity allocator (the code that was in Drop was moved to a new function delete_all_entities and now Drop calls that.) It also drops all the chunks in storage which in turn calls drop on all components. Event subscriptions and the command buffer are left intact.