### PR TITLE
Made getters ArchetypeId public.

### DIFF
--- a/legion_core/src/storage.rs
+++ b/legion_core/src/storage.rs
@@ -457,9 +457,9 @@ impl ArchetypeId {
         ArchetypeId(world_id, index)
     }
 
-    fn index(self) -> ArchetypeIndex { self.1 }
+    pub fn index(self) -> ArchetypeIndex { self.1 }
 
-    fn world(self) -> WorldId { self.0 }
+    pub fn world(self) -> WorldId { self.0 }
 }
 
 /// Contains all of the tags attached to the entities in each chunk.


### PR DESCRIPTION
When I receive an event I can't access the `ArchetypeId`. All the other index types do have public fields. I propose to do the same for this type. I need to know the internals of this type in order to use the events. Otherwise, they are pretty useless, because reconstruction of the game world can't happen. 

```rust
ArchetypeCreated(ArchetypeId(WorldId(1, 0), ArchetypeIndex(0)))
ChunkCreated(ChunkId(ArchetypeId(WorldId(1, 0), ArchetypeIndex(0)), SetIndex(0), ChunkIndex(0)))
EntityInserted(Entity { index: 63, version: 1 }, ChunkId(ArchetypeId(WorldId(1, 0), ArchetypeIndex(0)), SetIndex(0), ChunkIndex(0)))
```