### PR TITLE
Entity component tag types

### DIFF
--- a/legion_core/src/world.rs
+++ b/legion_core/src/world.rs
@@ -731,6 +731,31 @@ impl World {
     /// Determines if the given `Entity` is alive within this `World`.
     pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
 
+    /// Returns the entity's component types, if the entity exists.
+    pub fn entity_component_types(&self, entity: Entity) -> Option<&[(ComponentTypeId, ComponentMeta)]> {
+        if !self.is_alive(entity) {
+            return None
+        }
+        let location = self
+            .entity_allocator
+            .get_location(entity.index());
+        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        archetype.map(|archetype| archetype.description().components())
+    }
+
+    /// Returns the entity's tag types, if the entity exists.
+    pub fn entity_tag_types(&self, entity: Entity) -> Option<&[(TagTypeId, TagMeta)]> {
+        if !self.is_alive(entity) {
+            return None
+        }
+        let location = self
+            .entity_allocator
+            .get_location(entity.index());
+        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        archetype.map(|archetype| archetype.description().tags())
+        
+    }
+
     /// Iteratively defragments the world's internal memory.
     ///
     /// This compacts entities into fewer more continuous chunks.

--- a/legion_core/src/world.rs
+++ b/legion_core/src/world.rs
@@ -732,28 +732,30 @@ impl World {
     pub fn is_alive(&self, entity: Entity) -> bool { self.entity_allocator.is_alive(entity) }
 
     /// Returns the entity's component types, if the entity exists.
-    pub fn entity_component_types(&self, entity: Entity) -> Option<&[(ComponentTypeId, ComponentMeta)]> {
+    pub fn entity_component_types(
+        &self,
+        entity: Entity,
+    ) -> Option<&[(ComponentTypeId, ComponentMeta)]> {
         if !self.is_alive(entity) {
-            return None
+            return None;
         }
-        let location = self
-            .entity_allocator
-            .get_location(entity.index());
-        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        let location = self.entity_locations.get(entity);
+        let archetype = location
+            .map(|location| self.storage().archetype(location.archetype()))
+            .unwrap_or(None);
         archetype.map(|archetype| archetype.description().components())
     }
 
     /// Returns the entity's tag types, if the entity exists.
     pub fn entity_tag_types(&self, entity: Entity) -> Option<&[(TagTypeId, TagMeta)]> {
         if !self.is_alive(entity) {
-            return None
+            return None;
         }
-        let location = self
-            .entity_allocator
-            .get_location(entity.index());
-        let archetype = location.map(|location| self.storage().archetypes().get(location.archetype())).flatten();
+        let location = self.entity_locations.get(entity);
+        let archetype = location
+            .map(|location| self.storage().archetype(location.archetype()))
+            .unwrap_or(None);
         archetype.map(|archetype| archetype.description().tags())
-        
     }
 
     /// Iteratively defragments the world's internal memory.

--- a/tests/world_api.rs
+++ b/tests/world_api.rs
@@ -1,4 +1,6 @@
 use legion::prelude::*;
+use legion::storage::ComponentTypeId;
+use legion::storage::TagTypeId;
 use std::collections::HashSet;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -547,4 +549,43 @@ fn iter_entities() {
 
     // Verify that no extra entities are included
     assert!(entities.is_empty());
+}
+
+// Test that World::entity_component_types returns the correct ComponentTypeId
+#[test]
+fn entity_component_types() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    let shared = (Model(5),);
+    let components = vec![(Pos(1., 2., 3.),)];
+
+    let entity = world.insert(shared, components)[0];
+
+    let component_types = world.entity_component_types(entity).unwrap();
+    let component_type_ids: Vec<ComponentTypeId> =
+        component_types.iter().map(|(id, _)| *id).collect();
+    assert_eq!(1, component_type_ids.len());
+    assert!(component_type_ids.contains(&ComponentTypeId::of::<Pos>()));
+}
+
+// Test that World::entity_tag_types returns the correct TagTypeId
+#[test]
+fn entity_tag_types() {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let universe = Universe::new();
+    let mut world = universe.create_world();
+
+    let shared = (Model(5),);
+    let components = vec![(Pos(1., 2., 3.),)];
+
+    let entity = world.insert(shared, components)[0];
+
+    let tag_types = world.entity_tag_types(entity).unwrap();
+    let tag_type_ids: Vec<TagTypeId> = tag_types.iter().map(|(id, _)| *id).collect();
+    assert_eq!(1, tag_type_ids.len());
+    assert!(tag_type_ids.contains(&TagTypeId::of::<Model>()));
 }


### PR DESCRIPTION
This returns the ComponentTypeId/ComponentMeta and TagTypeId/TagMeta for all components/tags associated with an entity. We are using this for serialization/deserialization.

This was originally embedded in #113 but I'm pulling it out separately