### PR TITLE
Add AsMut for RefMut and RefMapMut

### DIFF
--- a/legion_core/src/borrow.rs
+++ b/legion_core/src/borrow.rs
@@ -397,6 +397,11 @@ impl<'a, T: 'a> AsRef<T> for RefMut<'a, T> {
     fn as_ref(&self) -> &T { self.value }
 }
 
+impl<'a, T: 'a> AsMut<T> for RefMut<'a, T> {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut T { self.value }
+}
+
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMut<'a, T> {
     #[inline(always)]
     fn borrow(&self) -> &T { self.value }
@@ -519,6 +524,11 @@ impl<'a, T: 'a> DerefMut for RefMapMut<'a, T> {
 impl<'a, T: 'a> AsRef<T> for RefMapMut<'a, T> {
     #[inline(always)]
     fn as_ref(&self) -> &T { &self.value }
+}
+
+impl<'a, T: 'a> AsMut<T> for RefMapMut<'a, T> {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut T { &mut self.value }
 }
 
 impl<'a, T: 'a> std::borrow::Borrow<T> for RefMapMut<'a, T> {


### PR DESCRIPTION
I needed this to deal with `TryWrite<...>` in a query so I could pass in an `Option<RefMut<...>>` to a function and interact with the interior by writing `if Some(x) = x.as_mut() { ... }`. I'm not sure that was necessarily the best way of doing it, but I figure not implementing `AsMut` for these two structs was probably an oversight so here's a pull request! :smile: