### PR TITLE
Clearer documentation of safe usage of _unchecked functions on queries

### DIFF
--- a/legion_core/src/query.rs
+++ b/legion_core/src/query.rs
@@ -940,7 +940,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -996,7 +998,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1050,7 +1054,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1104,7 +1110,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1140,7 +1148,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1177,7 +1187,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1246,7 +1258,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1298,7 +1312,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -1350,7 +1366,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///

--- a/legion_systems/src/system.rs
+++ b/legion_systems/src/system.rs
@@ -146,7 +146,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -187,7 +189,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -240,7 +244,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -293,7 +299,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -332,7 +340,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -376,7 +386,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -429,7 +441,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///
@@ -480,7 +494,9 @@ where
     ///
     /// # Safety
     ///
-    /// Incorrectly accessing components that are already borrowed elsewhere is undefined behavior.
+    /// The normal borrowing restrictions apply for the duration of the iteration:
+    /// * Components borrowed with `Read` access must not be borrowed mutably elsewhere.
+    /// * Components borrowed with `Write` access must not be borrowed elsewhere at all.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The current documentation of these functions was unclear to me, so I improved it based on what I think is correct. If my interpretation is wrong, I'll fix it.