### PR TITLE
Remove Option from parts of the Resource API

### DIFF
--- a/legion_systems/src/resource.rs
+++ b/legion_systems/src/resource.rs
@@ -16,7 +16,9 @@ pub struct ResourceTypeId(TypeId);
 #[cfg(not(feature = "ffi"))]
 impl ResourceTypeId {
     /// Gets the component type ID that represents type `T`.
-    pub fn of<T: Resource>() -> Self { Self(TypeId::of::<T>()) }
+    pub fn of<T: Resource>() -> Self {
+        Self(TypeId::of::<T>())
+    }
 }
 
 #[cfg(feature = "ffi")]
@@ -27,7 +29,9 @@ pub struct ResourceTypeId(TypeId, u32);
 #[cfg(feature = "ffi")]
 impl ResourceTypeId {
     /// Gets the component type ID that represents type `T`.
-    pub fn of<T: Resource>() -> Self { Self(TypeId::of::<T>(), 0) }
+    pub fn of<T: Resource>() -> Self {
+        Self(TypeId::of::<T>(), 0)
+    }
 }
 
 /// Trait which is implemented for tuples of resources and singular resources. This abstracts
@@ -96,12 +100,16 @@ pub struct PreparedRead<T: Resource> {
     resource: *const T,
 }
 impl<T: Resource> PreparedRead<T> {
-    pub(crate) unsafe fn new(resource: *const T) -> Self { Self { resource } }
+    pub(crate) unsafe fn new(resource: *const T) -> Self {
+        Self { resource }
+    }
 }
 impl<T: Resource> Deref for PreparedRead<T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target { unsafe { &*self.resource } }
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.resource }
+    }
 }
 unsafe impl<T: Resource> Send for PreparedRead<T> {}
 unsafe impl<T: Resource> Sync for PreparedRead<T> {}
@@ -119,14 +127,20 @@ pub struct PreparedWrite<T: Resource> {
 impl<T: Resource> Deref for PreparedWrite<T> {
     type Target = T;
 
-    fn deref(&self) -> &Self::Target { unsafe { &*self.resource } }
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.resource }
+    }
 }
 
 impl<T: Resource> DerefMut for PreparedWrite<T> {
-    fn deref_mut(&mut self) -> &mut T { unsafe { &mut *self.resource } }
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.resource }
+    }
 }
 impl<T: Resource> PreparedWrite<T> {
-    pub(crate) unsafe fn new(resource: *mut T) -> Self { Self { resource } }
+    pub(crate) unsafe fn new(resource: *mut T) -> Self {
+        Self { resource }
+    }
 }
 unsafe impl<T: Resource> Send for PreparedWrite<T> {}
 unsafe impl<T: Resource> Sync for PreparedWrite<T> {}

--- a/legion_systems/src/schedule.rs
+++ b/legion_systems/src/schedule.rs
@@ -119,7 +119,9 @@ unsafe impl Sync for SystemBox {}
 
 impl SystemBox {
     #[cfg(feature = "par-schedule")]
-    unsafe fn get(&self) -> &dyn Schedulable { std::ops::Deref::deref(&*self.0.get()) }
+    unsafe fn get(&self) -> &dyn Schedulable {
+        std::ops::Deref::deref(&*self.0.get())
+    }
 
     #[allow(clippy::mut_from_ref)]
     unsafe fn get_mut(&self) -> &mut dyn Schedulable {
@@ -476,7 +478,9 @@ impl Builder {
     }
 
     /// Finalizes the builder into a `Schedule`.
-    pub fn build(self) -> Schedule { self.into() }
+    pub fn build(self) -> Schedule {
+        self.into()
+    }
 }
 
 impl Default for Builder {
@@ -527,7 +531,9 @@ pub struct Schedule {
 
 impl Schedule {
     /// Creates a new schedule builder.
-    pub fn builder() -> Builder { Builder::default() }
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
 
     /// Executes all of the steps in the schedule.
     pub fn execute(&mut self, world: &mut World, resources: &mut Resources) {
@@ -559,7 +565,9 @@ impl Schedule {
     }
 
     /// Converts the schedule into a vector of steps.
-    pub fn into_vec(self) -> Vec<Step> { self.steps }
+    pub fn into_vec(self) -> Vec<Step> {
+        self.steps
+    }
 }
 
 impl From<Builder> for Schedule {
@@ -571,7 +579,9 @@ impl From<Builder> for Schedule {
 }
 
 impl From<Vec<Step>> for Schedule {
-    fn from(steps: Vec<Step>) -> Self { Self { steps } }
+    fn from(steps: Vec<Step>) -> Self {
+        Self { steps }
+    }
 }
 
 #[cfg(test)]

--- a/legion_systems/src/system.rs
+++ b/legion_systems/src/system.rs
@@ -608,7 +608,9 @@ where
                 bitset.insert(id);
             });
     }
-    unsafe fn prepare(&mut self) -> Self::Queries { SystemQuery::<AV, AF>::new(self) }
+    unsafe fn prepare(&mut self) -> Self::Queries {
+        SystemQuery::<AV, AF>::new(self)
+    }
 }
 
 impl_queryset_tuple!(A);
@@ -767,7 +769,9 @@ impl SubWorld {
 
     /// Determines if the given `Entity` is alive within this `World`.
     #[inline]
-    pub fn is_alive(&self, entity: Entity) -> bool { unsafe { (*self.world).is_alive(entity) } }
+    pub fn is_alive(&self, entity: Entity) -> bool {
+        unsafe { (*self.world).is_alive(entity) }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -846,7 +850,9 @@ where
         Queries = <Q as QuerySet>::Queries,
     >,
 {
-    fn name(&self) -> &SystemId { &self.name }
+    fn name(&self) -> &SystemId {
+        &self.name
+    }
 
     fn reads(&self) -> (&[ResourceTypeId], &[ComponentTypeId]) {
         (&self.access.resources.reads, &self.access.components.reads)
@@ -864,7 +870,9 @@ where
         }
     }
 
-    fn accesses_archetypes(&self) -> &ArchetypeAccess { &self.archetypes }
+    fn accesses_archetypes(&self) -> &ArchetypeAccess {
+        &self.archetypes
+    }
 
     fn command_buffer_mut(&self, world: WorldId) -> Option<RefMut<CommandBuffer>> {
         self.command_buffer.get(&world).map(|cmd| cmd.get_mut())


### PR DESCRIPTION
It shouldn't be necessary to return an Option<T> from get_default, get_or_insert, get_or_insert_with etc. Is it okay to remove them?

The first commit does some formatting stuff, the second changes the API and adds some tests.