### PR TITLE
Add data init and dispose functions to systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rayon = { version = "1.3", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 erased-serde = { version = "0.3", optional = true }
 crossbeam-channel = {version ="0.4", optional = true}
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/internals/systems/schedule.rs
+++ b/src/internals/systems/schedule.rs
@@ -37,6 +37,7 @@ use std::iter::repeat;
 pub trait Schedulable: Runnable + Send + Sync {}
 impl<T> Schedulable for T where T: Runnable + Send + Sync {}
 
+/// Trait describing a thread local system that has exclusive access to [World].
 pub trait ThreadLocalRunnable {
     /// Allows system to initialize data stored in resources or world.
     fn init(&mut self, _world: &mut World, _resourcess: &mut Resources) {}

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3,6 +3,6 @@
 pub use crate::internals::systems::{
     command::{CommandBuffer, WorldWritable},
     resources::{Fetch, Resource, ResourceSet, ResourceTypeId, Resources},
-    schedule::{Builder, Executor, Runnable, Schedulable, Schedule, Step},
+    schedule::{Builder, Executor, Runnable, Schedulable, Schedule, Step, ThreadLocalRunnable},
     system::{QuerySet, System, SystemAccess, SystemBuilder, SystemFn, SystemId},
 };


### PR DESCRIPTION
This PR is based on the amethyst discord discussion regarding system initialization and dispose.

In amethyst we have a lot of systems that have to initialize resources that they use prior to first execution. This was achieved by passing `World` and `Resources` to the system creation function so any required resources could be initialized. It works, but the nested syntax doesn't look too nice. However, there is no way to dispose of those resources once schedule is destroyed. Implementing this would require a big wrapper around all legion types and is really inconvenient. So instead I propose to add these utility function directly into legion.

Here is how a system would look like:
```rust
pub fn create_my_system() -> impl Schedulable {
    SystemBuilder::new("my_system")
        .write_resource::<MyResource>()
        .with_init(|_world, resources| {
            resources.insert(MyResource::default());
        })
        .with_dispose(|_world, resources| {
            let my_res = resources.remove::<MyResource>();
            my_res.unwrap().do_some_cleanup();
        })
        .build(|_, _, my_res, _| {
            // do something with my_res
        });
}
```

Init and dispose functions for all systems are called by `Schedule::init` and `Schedule::dispose` in the order of system insertion. It is up to the user to call those functions.

Thread local systems are now a `ThreadLocalRunnable` trait which has `init`, `dispose` and `run` functions and implements `Runnable` trait. This simplifies `Schedule` code and API a bit. Unfortunatelly, I couldn't find a way to make `SystemId` static, so I used the `lazy_static` library. Any ideas how to solve this without additional lib?

This is a rough proposal and I'm looking for feedback