### PR TITLE
#[system] procedural macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,15 @@ edition = "2018"
 travis-ci = { repository = "TomGillen/legion", branch = "master" }
 
 [features]
-default = ["par-iter", "serialize", "crossbeam-events"]
+default = ["par-iter", "serialize", "crossbeam-events", "codegen"]
 par-iter = ["rayon"]
 extended-tuple-impls = []
 serialize = ["serde", "erased-serde", "uuid/serde"]
 crossbeam-events = ["crossbeam-channel"]
+codegen = ["legion_codegen"]
 
 [dependencies]
+legion_codegen = { path = "codegen", version = "0.3", optional = true }
 smallvec = "1.4"
 itertools = "0.9"
 downcast-rs = "1.2"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "legion_codegen"
+version = "0.3.0"
+authors = ["Thomas Gillen <thomas.gillen@googlemail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = "1.0"
+proc-macro2 = "1.0"
+thiserror = "1.0"
+
+[dev-dependencies]
+legion = { path = "..", version = "0.3" }
+trybuild = "1.0"

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,0 +1,736 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{format_ident, quote, quote_spanned, ToTokens};
+use syn::{
+    parse_macro_input, parse_quote, Attribute, Expr, GenericArgument, Generics, Ident, Index,
+    ItemFn, Lit, Meta, PathArguments, Signature, Type, Visibility,
+};
+
+/// Wraps a function in a system, and generates a new function which constructs that system.
+///
+/// There are three types of systems: `simple` (default), `for_each` and `par_for_each`.
+/// By default, the system macro will create a new function named `<attributed_fn_name>_system`
+/// which can be called to construct the system.
+///
+/// # Examples
+///
+/// By default, the system function is called once when the system runs.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::Schedule;
+/// #[system]
+/// fn hello_world() {
+///    println!("hello world");
+/// }
+///
+/// Schedule::builder()
+///     .add_system(hello_world_system())
+///     .build();
+/// ```
+///
+/// The function can request resources with reference parameters marked with
+/// the `#[resource]` attribute.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::Schedule;
+/// # struct Person { name: String }
+/// #[system]
+/// fn hello_world(#[resource] person: &Person) {
+///    println!("hello, {}", person.name);
+/// }
+/// ```
+///
+/// Systems can also request a world or command buffer.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::{Schedule, systems::CommandBuffer, world::SubWorld};
+/// # struct Person { name: &'static str }
+/// #[system]
+/// fn create_entity(world: &mut SubWorld, cmd: &mut CommandBuffer) {
+///    cmd.push((1usize, false, Person { name: "Jane Doe" }));
+/// }
+/// ```
+///
+/// Systems can declare access to component types with the `#[read_component]` and
+/// `#[write_component]` attributes.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::{Schedule, world::SubWorld, Read, Write, IntoQuery};
+/// # struct Time;
+/// #[system]
+/// #[read_component(usize)]
+/// #[write_component(bool)]
+/// fn run_query(world: &mut SubWorld) {
+///     let mut query = <(Read<usize>, Write<bool>)>::query();
+///     for (a, b) in query.iter_mut(world) {
+///         println!("{} {}", a, b);
+///     }
+/// }
+/// ```
+///
+/// `for_each` and `par_for_each` system types can be used to implement the query for you.
+/// References will be interpreted as `Read<T>` and `Write<T>`, while options of references
+/// (e.g. `Option<&Position>`) will be interpreted as `TryRead<T>` and `TryWrite<T>`. You can
+/// request the entity ID via a `&Entity` parameter.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # struct Position { x: f32 }
+/// # struct Velocity { x: f32 }
+/// # struct Time { seconds: f32 }
+/// #[system(for_each)]
+/// fn update_positions(pos: &mut Position, vel: &Velocity, #[resource] time: &Time) {
+///     pos.x += vel.x * time.seconds;
+/// }
+/// ```
+///
+/// `for_each` and `par_for_each` systems can request attitional filters for their query via the
+/// `#[filter]` attribute.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::maybe_changed;
+/// # struct Position { x: f32 }
+/// # struct Velocity { x: f32 }
+/// # struct Time { seconds: f32 }
+/// #[system(for_each)]
+/// #[filter(maybe_changed::<Position>())]
+/// fn update_positions(pos: &mut Position, vel: &Velocity, #[resource] time: &Time) {
+///     pos.x += vel.x * time.seconds;
+/// }
+/// ```
+///
+/// Systems can contain their own state. Add a reference marked with the `#[state]` parameter to
+/// your function. This state will be initialized when you construct the system.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::Schedule;
+/// #[system]
+/// fn stateful(#[state] counter: &mut usize) {
+///     *counter += 1;
+///     println!("state: {}", counter);
+/// }
+///
+/// Schedule::builder()
+///      // initialize state when you construct the system
+///     .add_system(stateful_system(5usize))
+///     .build();
+/// ```
+///
+/// Systems can contain generic parameters.
+///
+/// ```
+/// # use legion_codegen::system;
+/// # use legion::{storage::Component, Schedule};
+/// # use std::fmt::Debug;
+/// # #[derive(Debug)]
+/// # struct Position;
+/// #[system(for_each)]
+/// fn print_component<T: Component + Debug>(component: &T) {
+///     println!("{:?}", component);
+/// }
+///
+/// Schedule::builder()
+///      // supply generic parameters when constructing the system
+///     .add_system(print_component_system::<Position>())
+///     .build();
+/// ```
+#[proc_macro_attribute]
+pub fn system(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = if attr.is_empty() {
+        SystemAttr::default()
+    } else {
+        let meta = parse_macro_input!(attr as Meta);
+        match SystemAttr::parse_meta(&meta) {
+            Ok(attr) => attr,
+            Err(error) => return error.emit(),
+        }
+    };
+
+    let mut input = parse_macro_input!(item as ItemFn);
+    let mut config = match Config::parse(attr, &mut input) {
+        Ok(config) => config,
+        Err(error) => return error.emit(),
+    };
+    let system_constructor = config.generate();
+
+    let output = quote! {
+        #system_constructor
+        #[allow(dead_code)]
+        #input
+    };
+
+    TokenStream::from(output)
+}
+
+#[derive(thiserror::Error, Debug)]
+enum Error {
+    #[error("system types must be one of `simple`, `for_each` or `par_for_each`")]
+    UnexpectedSystemType(Span),
+    #[error("duplicate system constructor function name")]
+    DuplicateConstructorName,
+    #[error("duplicate system type")]
+    DuplicateSystemType,
+    #[error("invalid key")]
+    InvalidKey(Span),
+    #[error("system functions must not recieve self")]
+    SelfNotAllowed,
+    #[error("option arguments must contain a component reference")]
+    InvalidOptionArgument(Span),
+    #[error(
+        "system function parameters must be `CommandBuffer` or `SubWorld` references, \
+[optioned] component references, state references, or resource references"
+    )]
+    InvalidArgument(Span),
+    #[error("expected component type")]
+    ExpectedComponentType(Span),
+    #[error("expected filter expression")]
+    ExpectedFilterExpression(Span),
+}
+
+impl Error {
+    fn span(&self) -> Span {
+        match self {
+            Error::UnexpectedSystemType(span) => *span,
+            Error::InvalidKey(span) => *span,
+            Error::InvalidOptionArgument(span) => *span,
+            Error::InvalidArgument(span) => *span,
+            _ => Span::call_site(),
+        }
+    }
+
+    fn emit(&self) -> TokenStream {
+        let message = format!("{}", self);
+        let tokens = quote_spanned!(self.span() => compile_error!(#message));
+        TokenStream::from(tokens)
+    }
+}
+
+#[derive(Default)]
+struct SystemAttr {
+    constructor_name: Option<Lit>,
+    system_type: Option<SystemType>,
+}
+
+impl SystemAttr {
+    fn new(constructor_name: Option<Lit>, system_type: Option<SystemType>) -> Self {
+        Self {
+            constructor_name,
+            system_type,
+        }
+    }
+
+    fn parse_meta(meta: &Meta) -> Result<Self, Error> {
+        let result = match meta {
+            Meta::Path(path) => {
+                let ident = path.get_ident().expect("expected system type");
+                if ident == "for_each" {
+                    Self::new(None, Some(SystemType::ForEach))
+                } else if ident == "par_for_each" {
+                    Self::new(None, Some(SystemType::ParForEach))
+                } else if ident == "simple" {
+                    Self::new(None, Some(SystemType::Simple))
+                } else {
+                    return Err(Error::UnexpectedSystemType(ident.span()));
+                }
+            }
+            Meta::List(items) => {
+                let mut n = None;
+                let mut s = None;
+                for item in &items.nested {
+                    let Self {
+                        constructor_name,
+                        system_type,
+                    } = match item {
+                        syn::NestedMeta::Meta(meta) => Self::parse_meta(&meta)?,
+                        syn::NestedMeta::Lit(_) => panic!("unexpected literal"),
+                    };
+                    if let Some(constructor_name) = constructor_name {
+                        if n.replace(constructor_name).is_some() {
+                            return Err(Error::DuplicateConstructorName);
+                        }
+                    }
+                    if let Some(system_type) = system_type {
+                        if s.replace(system_type).is_some() {
+                            return Err(Error::DuplicateSystemType);
+                        }
+                    }
+                }
+                Self::new(n, s)
+            }
+            Meta::NameValue(name_value) => match name_value.path.get_ident().map(|ident| ident) {
+                Some(ident) if ident == "ctor" => Self::new(Some(name_value.lit.clone()), None),
+                Some(ident) => return Err(Error::InvalidKey(ident.span())),
+                _ => return Err(Error::InvalidKey(Span::call_site())),
+            },
+        };
+
+        Ok(result)
+    }
+}
+
+struct Sig {
+    ident: Ident,
+    parameters: Vec<Parameter>,
+    query: Vec<Type>,
+    read_resources: Vec<Type>,
+    write_resources: Vec<Type>,
+    state_args: Vec<Type>,
+    generics: Generics,
+}
+
+impl Sig {
+    fn parse(item: &mut Signature) -> Result<Self, Error> {
+        let mut parameters = Vec::new();
+        let mut query = Vec::<Type>::new();
+        let mut read_resources = Vec::new();
+        let mut write_resources = Vec::new();
+        let mut state_args = Vec::new();
+        for param in &mut item.inputs {
+            match param {
+                syn::FnArg::Receiver(_) => return Err(Error::SelfNotAllowed),
+                syn::FnArg::Typed(arg) => match arg.ty.as_ref() {
+                    Type::Path(ty_path) => {
+                        let ident = &ty_path.path.segments[0].ident;
+                        if ident == "Option" {
+                            match &ty_path.path.segments[0].arguments {
+                                PathArguments::AngleBracketed(bracketed) => {
+                                    let arg = bracketed.args.iter().next().unwrap();
+                                    match arg {
+                                        GenericArgument::Type(ty) => match ty {
+                                            Type::Reference(ty) => {
+                                                let mutable = ty.mutability.is_some();
+                                                parameters.push(Parameter::Component(query.len()));
+                                                let elem = &ty.elem;
+                                                if mutable {
+                                                    query.push(
+                                                        parse_quote!(::legion::TryWrite<#elem>),
+                                                    );
+                                                } else {
+                                                    query.push(
+                                                        parse_quote!(::legion::TryRead<#elem>),
+                                                    );
+                                                }
+                                            }
+                                            _ => {
+                                                return Err(Error::InvalidOptionArgument(
+                                                    ident.span(),
+                                                ))
+                                            }
+                                        },
+                                        _ => panic!(),
+                                    }
+                                }
+                                _ => panic!(),
+                            }
+                        } else {
+                            return Err(Error::InvalidArgument(ident.span()));
+                        }
+                    }
+                    Type::Reference(ty) if is_type(&ty.elem, &["legion", "CommandBuffer"]) => {
+                        if ty.mutability.is_some() {
+                            parameters.push(Parameter::CommandBufferMut);
+                        } else {
+                            parameters.push(Parameter::CommandBuffer);
+                        }
+                    }
+                    Type::Reference(ty) if is_type(&ty.elem, &["legion", "SubWorld"]) => {
+                        if ty.mutability.is_some() {
+                            parameters.push(Parameter::SubWorldMut);
+                        } else {
+                            parameters.push(Parameter::SubWorld);
+                        }
+                    }
+                    Type::Reference(ty) if is_type(&ty.elem, &["legion", "Entity"]) => {
+                        parameters.push(Parameter::Component(query.len()));
+                        query.push(parse_quote!(::legion::Entity));
+                    }
+                    Type::Reference(ty) => {
+                        let mutable = ty.mutability.is_some();
+                        let resource = Self::find_remove_arg_attr(&mut arg.attrs);
+                        match resource {
+                            Some(ArgAttr::Resource) => {
+                                if mutable {
+                                    parameters.push(Parameter::ResourceMut(write_resources.len()));
+                                    write_resources.push(ty.elem.as_ref().clone());
+                                } else {
+                                    parameters.push(Parameter::Resource(read_resources.len()));
+                                    read_resources.push(ty.elem.as_ref().clone());
+                                }
+                            }
+                            Some(ArgAttr::State) => {
+                                if mutable {
+                                    parameters.push(Parameter::StateMut(state_args.len()));
+                                } else {
+                                    parameters.push(Parameter::State(state_args.len()));
+                                }
+                                state_args.push(ty.elem.as_ref().clone());
+                            }
+                            None => {
+                                parameters.push(Parameter::Component(query.len()));
+                                let elem = &ty.elem;
+                                if mutable {
+                                    query.push(parse_quote!(::legion::Write<#elem>));
+                                } else {
+                                    query.push(parse_quote!(::legion::Read<#elem>));
+                                }
+                            }
+                        }
+                    }
+                    _ => return Err(Error::InvalidArgument(Span::call_site())),
+                },
+            }
+        }
+
+        Ok(Self {
+            ident: item.ident.clone(),
+            generics: item.generics.clone(),
+            parameters,
+            query,
+            read_resources,
+            write_resources,
+            state_args,
+        })
+    }
+
+    fn find_remove_arg_attr(attributes: &mut Vec<Attribute>) -> Option<ArgAttr> {
+        for i in (0..attributes.len()).rev() {
+            match attributes[i].path.get_ident() {
+                Some(ident) if ident == "resource" => {
+                    attributes.remove(i);
+                    return Some(ArgAttr::Resource);
+                }
+                Some(ident) if ident == "state" => {
+                    attributes.remove(i);
+                    return Some(ArgAttr::State);
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+}
+
+enum ArgAttr {
+    Resource,
+    State,
+}
+
+fn is_type(ty: &Type, segments: &[&str]) -> bool {
+    if let Type::Path(path) = ty {
+        path.path
+            .segments
+            .iter()
+            .rev()
+            .zip(segments.iter().rev())
+            .all(|(a, b)| a.ident == b)
+    } else {
+        false
+    }
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum SystemType {
+    Simple,
+    ForEach,
+    ParForEach,
+}
+
+impl SystemType {
+    fn requires_query(&self) -> bool {
+        match self {
+            SystemType::Simple => false,
+            SystemType::ForEach => true,
+            SystemType::ParForEach => true,
+        }
+    }
+}
+
+enum Parameter {
+    CommandBuffer,
+    CommandBufferMut,
+    SubWorld,
+    SubWorldMut,
+    Component(usize),
+    Resource(usize),
+    ResourceMut(usize),
+    State(usize),
+    StateMut(usize),
+}
+
+struct Config {
+    attr: SystemAttr,
+    visibility: Visibility,
+    read_components: Vec<Type>,
+    write_components: Vec<Type>,
+    filters: Vec<Expr>,
+    signature: Sig,
+}
+
+impl Config {
+    fn parse(attr: SystemAttr, item: &mut ItemFn) -> Result<Self, Error> {
+        // parse attributes, extract read/write component/resource and filters
+        let mut to_remove = Vec::new();
+        let mut read_components = Vec::new();
+        let mut write_components = Vec::new();
+        let mut filters = Vec::new();
+        for (i, attribute) in item.attrs.iter().enumerate() {
+            if let Some(ident) = attribute.path.get_ident() {
+                if ident == "read_component" {
+                    let component = attribute
+                        .parse_args()
+                        .map_err(|_| Error::ExpectedComponentType(ident.span()))?;
+                    read_components.push(component);
+                    to_remove.push(i);
+                }
+                if ident == "write_component" {
+                    let component = attribute
+                        .parse_args()
+                        .map_err(|_| Error::ExpectedComponentType(ident.span()))?;
+                    write_components.push(component);
+                    to_remove.push(i);
+                }
+                if ident == "filter" {
+                    let filter = attribute
+                        .parse_args()
+                        .map_err(|_| Error::ExpectedFilterExpression(ident.span()))?;
+                    filters.push(filter);
+                    to_remove.push(i);
+                }
+            }
+        }
+
+        // remove helper attributes
+        for i in to_remove.iter().rev() {
+            item.attrs.remove(*i);
+        }
+
+        // parse signature, extract cmd, world, components and resources
+        let signature = Sig::parse(&mut item.sig)?;
+
+        Ok(Config {
+            attr,
+            visibility: item.vis.clone(),
+            read_components,
+            write_components,
+            filters,
+            signature,
+        })
+    }
+
+    fn generate(&mut self) -> impl ToTokens {
+        let Self {
+            attr,
+            visibility,
+            read_components,
+            write_components,
+            filters,
+            signature,
+        } = self;
+
+        let system_type = attr.system_type.unwrap_or(SystemType::Simple);
+
+        // validation
+        if !signature.query.is_empty() && system_type == SystemType::Simple {
+            panic!("simple systems cannot contain component references, consider using `#[system(for_each)]`");
+        }
+
+        if signature.query.is_empty() && system_type != SystemType::Simple {
+            panic!("for_each and par_for_each systems require at least one component parameter");
+        }
+
+        if signature.generics.lifetimes().next().is_some() {
+            panic!("system functions must not contain lifetime generic parameters");
+        }
+
+        if system_type == SystemType::ParForEach {
+            if signature
+                .parameters
+                .iter()
+                .any(|param| matches!(param, Parameter::SubWorldMut))
+            {
+                panic!("par_for_each systems cannot accept mutable world references");
+            }
+            if signature
+                .parameters
+                .iter()
+                .any(|param| matches!(param, Parameter::ResourceMut(_)))
+            {
+                panic!("par_for_each systems cannot accept mutable resource references");
+            }
+            if signature
+                .parameters
+                .iter()
+                .any(|param| matches!(param, Parameter::CommandBufferMut))
+            {
+                panic!("par_for_each systems cannot accept mutable command buffer references");
+            }
+        }
+
+        // declare query
+        let query = if system_type.requires_query() {
+            let views = &signature.query;
+            quote! {
+                .with_query(
+                    <(#(#views),*)>::query()
+                    #(.filter(#filters))*
+                )
+            }
+        } else {
+            quote!()
+        };
+
+        // construct function arguments
+        let has_query = !signature.query.is_empty();
+        let single_resource =
+            (signature.read_resources.len() + signature.write_resources.len()) == 1;
+        let mut call_params = Vec::new();
+        let mut fn_params = Vec::new();
+        let mut world = None;
+        for param in &signature.parameters {
+            match param {
+                Parameter::CommandBuffer => call_params.push(quote!(cmd)),
+                Parameter::CommandBufferMut => call_params.push(quote!(cmd)),
+                Parameter::SubWorld => {
+                    if has_query {
+                        call_params.push(quote!(&world));
+                    } else {
+                        call_params.push(quote!(world));
+                    }
+                    world = Some(quote! {
+                        let (mut for_query, world) = world.split_for_query(query);
+                        let for_query = &mut for_query;
+                    });
+                }
+                Parameter::SubWorldMut => {
+                    if has_query {
+                        call_params.push(quote!(&mut world));
+                    } else {
+                        call_params.push(quote!(world));
+                    }
+                    world = Some(quote! {
+                        let (mut for_query, mut world) = world.split_for_query(query);
+                        let for_query = &mut for_query;
+                    });
+                }
+                Parameter::Component(_) if signature.query.len() == 1 => {
+                    call_params.push(quote!(components))
+                }
+                Parameter::Component(idx) => {
+                    let idx = Index::from(*idx);
+                    call_params.push(quote!(components.#idx));
+                }
+                Parameter::Resource(_) if single_resource => call_params.push(quote!(&*resources)),
+                Parameter::ResourceMut(_) if single_resource => {
+                    call_params.push(quote!(&mut *resources))
+                }
+                Parameter::Resource(idx) => {
+                    let idx = Index::from(*idx);
+                    call_params.push(quote!(&*resources.#idx));
+                }
+                Parameter::ResourceMut(idx) => {
+                    let idx = Index::from(*idx + signature.read_resources.len());
+                    call_params.push(quote!(&mut *resources.#idx));
+                }
+                Parameter::State(idx) => {
+                    let arg_name = format_ident!("state_{}", idx);
+                    let arg_type = &signature.state_args[*idx];
+                    call_params.push(quote!(&#arg_name));
+                    fn_params.push(quote!(#arg_name: #arg_type));
+                }
+                Parameter::StateMut(idx) => {
+                    let arg_name = format_ident!("state_{}", idx);
+                    let arg_type = &signature.state_args[*idx];
+                    call_params.push(quote!(&mut #arg_name));
+                    fn_params.push(quote!(mut #arg_name: #arg_type));
+                }
+            }
+        }
+
+        // construct function body
+        let fn_id = &signature.ident;
+        let type_params = signature
+            .generics
+            .type_params()
+            .map(|param| param.ident.clone());
+        let fn_call = quote!(#fn_id::<#(#type_params),*>(#(#call_params),*););
+        let world = world.unwrap_or_else(|| quote!(let for_query = world;));
+        let body = match system_type {
+            SystemType::Simple => fn_call,
+            SystemType::ForEach => quote! {
+                #world
+                query.for_each_mut(for_query, |components| {
+                    #fn_call
+                });
+            },
+            SystemType::ParForEach => quote! {
+                #world
+                query.par_for_each_mut(for_query, |components| {
+                    #fn_call
+                });
+            },
+        };
+
+        // construct our system
+        let system_name = fn_id.to_string();
+        let generic_parameter_names = if signature.generics.type_params().next().is_some() {
+            {
+                let param_names = signature
+                    .generics
+                    .type_params()
+                    .map(|param| param.ident.clone())
+                    .collect::<Vec<_>>();
+                quote! {
+                    let generic_names = "<".to_owned() + &[#(std::any::type_name::<#param_names>()),*].join(", ") + ">";
+                }
+            }
+        } else {
+            quote!(let generic_names = "";)
+        };
+        let read_resources = &signature.read_resources;
+        let write_resources = &signature.write_resources;
+        let builder = quote! {
+            use legion::IntoQuery;
+            #generic_parameter_names
+            ::legion::systems::SystemBuilder::new(format!("{}{}", #system_name, generic_names))
+                #(.read_component::<#read_components>())*
+                #(.write_component::<#write_components>())*
+                #(.read_resource::<#read_resources>())*
+                #(.write_resource::<#write_resources>())*
+                #query
+                .build(move |cmd, world, resources, query| {
+                    #body
+                })
+        };
+
+        // construct our system constructor function
+        let constructor_name = if let Some(name) = &attr.constructor_name {
+            let (name, span) = match name {
+                Lit::Str(name) => (name.value(), name.span()),
+                Lit::Char(name) => (name.value().to_string(), name.span()),
+                Lit::Verbatim(name) => (name.to_string(), name.span()),
+                _ => panic!("invalid system constructor name"),
+            };
+            Ident::new(&name, span)
+        } else {
+            format_ident!("{}_system", fn_id)
+        };
+
+        let generic_params = signature.generics.params.clone();
+        let where_clause = signature.generics.make_where_clause();
+
+        quote! {
+            #visibility fn #constructor_name<#generic_params>(#(#fn_params),*) -> impl ::legion::systems::Runnable
+            #where_clause
+            {
+                #builder
+            }
+        }
+    }
+}

--- a/codegen/tests/basic.rs
+++ b/codegen/tests/basic.rs
@@ -1,0 +1,127 @@
+use legion::{
+    storage::Component, systems::CommandBuffer, world::SubWorld, IntoQuery, Read, Schedule, Write,
+};
+use legion_codegen::system;
+use std::fmt::Debug;
+
+#[test]
+fn empty() {
+    #[system]
+    fn basic() {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_resource() {
+    #[system]
+    fn basic(#[resource] _: &usize) {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_mut_resource() {
+    #[system]
+    fn basic(#[resource] _: &mut usize) {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_world() {
+    #[system]
+    fn basic(_: &SubWorld) {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_mut_world() {
+    #[system]
+    fn basic(_: &mut SubWorld) {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_cmd() {
+    #[system]
+    fn basic(_: &CommandBuffer) {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_mut_cmd() {
+    #[system]
+    fn basic(_: &mut CommandBuffer) {}
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_components() {
+    #[system]
+    #[read_component(f32)]
+    #[write_component(usize)]
+    fn basic(world: &mut SubWorld) {
+        let mut query = <(Read<f32>, Write<usize>)>::query();
+        for (a, b) in query.iter_mut(world) {
+            println!("{:?} {:?}", a, b);
+        }
+    }
+
+    Schedule::builder().add_system(basic_system()).build();
+}
+
+#[test]
+fn with_generics() {
+    #[system]
+    #[read_component(T)]
+    fn basic<T: Component + Debug>(world: &mut SubWorld) {
+        let mut query = Read::<T>::query();
+        for t in query.iter_mut(world) {
+            println!("{:?}", t);
+        }
+    }
+
+    Schedule::builder()
+        .add_system(basic_system::<usize>())
+        .build();
+}
+
+#[test]
+fn with_generics_with_where() {
+    #[system]
+    #[read_component(T)]
+    fn basic<T>(world: &mut SubWorld)
+    where
+        T: Component + Debug,
+    {
+        let mut query = Read::<T>::query();
+        for t in query.iter_mut(world) {
+            println!("{:?}", t);
+        }
+    }
+
+    Schedule::builder()
+        .add_system(basic_system::<usize>())
+        .build();
+}
+
+#[test]
+fn with_state() {
+    #[system]
+    fn basic<T: 'static>(#[state] _: &T) {}
+
+    Schedule::builder().add_system(basic_system(false)).build();
+}
+
+#[test]
+fn with_mut_state() {
+    #[system]
+    fn basic<T: 'static>(#[state] _: &mut T) {}
+
+    Schedule::builder().add_system(basic_system(false)).build();
+}

--- a/codegen/tests/failures.rs
+++ b/codegen/tests/failures.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/failures/*.rs");
+}

--- a/codegen/tests/failures/par_mut_command.rs
+++ b/codegen/tests/failures/par_mut_command.rs
@@ -1,0 +1,9 @@
+#![allow(unused_imports)]
+
+use legion::{systems::CommandBuffer, Entity};
+use legion_codegen::system;
+
+#[system(par_for_each)]
+fn for_each(_: &Entity, _: &mut CommandBuffer) {}
+
+fn main() {}

--- a/codegen/tests/failures/par_mut_command.stderr
+++ b/codegen/tests/failures/par_mut_command.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> $DIR/par_mut_command.rs:6:1
+  |
+6 | #[system(par_for_each)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: par_for_each systems cannot accept mutable command buffer references

--- a/codegen/tests/failures/par_mut_resource.rs
+++ b/codegen/tests/failures/par_mut_resource.rs
@@ -1,0 +1,9 @@
+#![allow(unused_imports)]
+
+use legion::Entity;
+use legion_codegen::system;
+
+#[system(par_for_each)]
+fn for_each(_: &Entity, #[resource] _: &mut usize) {}
+
+fn main() {}

--- a/codegen/tests/failures/par_mut_resource.stderr
+++ b/codegen/tests/failures/par_mut_resource.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> $DIR/par_mut_resource.rs:6:1
+  |
+6 | #[system(par_for_each)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: par_for_each systems cannot accept mutable resource references

--- a/codegen/tests/failures/par_mut_world.rs
+++ b/codegen/tests/failures/par_mut_world.rs
@@ -1,0 +1,9 @@
+#![allow(unused_imports)]
+
+use legion::{world::SubWorld, Entity};
+use legion_codegen::system;
+
+#[system(par_for_each)]
+fn for_each(_: &Entity, _: &mut SubWorld) {}
+
+fn main() {}

--- a/codegen/tests/failures/par_mut_world.stderr
+++ b/codegen/tests/failures/par_mut_world.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> $DIR/par_mut_world.rs:6:1
+  |
+6 | #[system(par_for_each)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: par_for_each systems cannot accept mutable world references

--- a/codegen/tests/failures/value_argument.rs
+++ b/codegen/tests/failures/value_argument.rs
@@ -1,0 +1,6 @@
+use legion_codegen::system;
+
+#[system]
+fn value_arguement(_: usize) {}
+
+fn main() {}

--- a/codegen/tests/failures/value_argument.stderr
+++ b/codegen/tests/failures/value_argument.stderr
@@ -1,0 +1,20 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+ --> $DIR/value_argument.rs:4:23
+  |
+4 | fn value_arguement(_: usize) {}
+  |                       ^^^^^
+  |
+help: change the delimiters to curly braces
+  |
+4 | fn value_arguement(_: {}) {}
+  |                       ^
+help: add a semicolon
+  |
+4 | fn value_arguement(_: usize;) {}
+  |                            ^
+
+error: system function parameters must be `CommandBuffer` or `SubWorld` references, [optioned] component references, state references, or resource references
+ --> $DIR/value_argument.rs:4:23
+  |
+4 | fn value_arguement(_: usize) {}
+  |                       ^^^^^

--- a/codegen/tests/for_each.rs
+++ b/codegen/tests/for_each.rs
@@ -1,0 +1,81 @@
+use legion::{storage::Component, systems::CommandBuffer, world::SubWorld, Entity, Schedule};
+use legion_codegen::system;
+use std::fmt::Debug;
+
+#[test]
+fn empty() {
+    #[system(for_each)]
+    fn for_each(_: &Entity) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_resource() {
+    #[system(for_each)]
+    fn for_each(_: &Entity, #[resource] _: &usize) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_mut_resource() {
+    #[system(for_each)]
+    fn for_each(_: &Entity, #[resource] _: &mut usize) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_world() {
+    #[system(for_each)]
+    fn for_each(_: &Entity, _: &SubWorld) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_mut_world() {
+    #[system(for_each)]
+    fn for_each(_: &Entity, _: &mut SubWorld) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_cmd() {
+    #[system(for_each)]
+    fn for_each(_: &Entity, _: &CommandBuffer) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_mut_cmd() {
+    #[system(for_each)]
+    fn for_each(_: &Entity, _: &mut CommandBuffer) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_components() {
+    #[system(for_each)]
+    fn for_each(a: &f32, b: &mut usize) {
+        println!("{:?} {:?}", a, b);
+    }
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_generics() {
+    #[system(for_each)]
+    fn for_each<T: Component + Debug>(t: &T) {
+        println!("{:?}", t);
+    }
+
+    Schedule::builder()
+        .add_system(for_each_system::<usize>())
+        .build();
+}

--- a/codegen/tests/par_for_each.rs
+++ b/codegen/tests/par_for_each.rs
@@ -1,0 +1,57 @@
+use legion::{storage::Component, systems::CommandBuffer, world::SubWorld, Entity, Schedule};
+use legion_codegen::system;
+use std::fmt::Debug;
+
+#[test]
+fn empty() {
+    #[system(par_for_each)]
+    fn for_each(_: &Entity) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_resource() {
+    #[system(par_for_each)]
+    fn for_each(_: &Entity, #[resource] _: &usize) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_world() {
+    #[system(par_for_each)]
+    fn for_each(_: &Entity, _: &SubWorld) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_cmd() {
+    #[system(par_for_each)]
+    fn for_each(_: &Entity, _: &CommandBuffer) {}
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_components() {
+    #[system(par_for_each)]
+    fn for_each(a: &f32, b: &mut usize) {
+        println!("{:?} {:?}", a, b);
+    }
+
+    Schedule::builder().add_system(for_each_system()).build();
+}
+
+#[test]
+fn with_generics() {
+    #[system(par_for_each)]
+    fn for_each<T: Component + Debug>(t: &T) {
+        println!("{:?}", t);
+    }
+
+    Schedule::builder()
+        .add_system(for_each_system::<usize>())
+        .build();
+}

--- a/src/internals/query/view/mod.rs
+++ b/src/internals/query/view/mod.rs
@@ -33,7 +33,7 @@ pub mod write;
 /// Declares the default filter type used by a view when it is converted into a query.
 pub trait DefaultFilter {
     /// The filter constructed.
-    type Filter: EntityFilter;
+    type Filter: EntityFilter + 'static;
 }
 
 /// A type which can pull entitiy data out of a world.

--- a/src/internals/systems/schedule.rs
+++ b/src/internals/systems/schedule.rs
@@ -40,7 +40,7 @@ impl<T> Schedulable for T where T: Runnable + Send + Sync {}
 /// Trait describing a schedulable type. This is implemented by `System`
 pub trait Runnable {
     /// Gets the name of the system.
-    fn name(&self) -> &SystemId;
+    fn name(&self) -> Option<&SystemId>;
 
     /// Gets the resources and component types read by the system.
     fn reads(&self) -> (&[ResourceTypeId], &[ComponentTypeId]);

--- a/src/internals/systems/system.rs
+++ b/src/internals/systems/system.rs
@@ -110,7 +110,7 @@ impl<T: Into<Cow<'static, str>>> From<T> for SystemId {
 }
 
 /// The concrete type which contains the system closure provided by the user.  This struct should
-/// not be instantiated directly, and instead should be created using `SystemBuilder`.
+/// not be constructed directly, and instead should be created using `SystemBuilder`.
 ///
 /// Implements `Schedulable` which is consumable by the `StageExecutor`, executing the closure.
 ///
@@ -228,9 +228,8 @@ where
 // for this system. Access types are instead stored and abstracted in the top level vec here
 // so the underlying ResourceSet type functions from the queries don't need to allocate.
 // Otherwise, this leads to excessive alloaction for every call to reads/writes
-/// The core builder of `System` types, which are systems within Legion. Systems are implemented
-/// as singular closures for a given system - providing queries which should be cached for that
-/// system, as well as resource access and other metadata.
+
+/// A low level builder for constructing systems.
 /// ```rust
 /// # use legion::*;
 /// # #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,5 +208,8 @@ pub use crate::{
     world::{Entity, EntityStore, Universe, World, WorldOptions},
 };
 
+#[cfg(feature = "codegen")]
+pub use legion_codegen::system;
+
 #[cfg(feature = "serialize")]
 pub use crate::serialize::Registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@
 //! the perspective of each system.
 //!
 //! ```
+//! # #[cfg(feature = "codegen")] {
 //! # use legion::*;
 //! # struct Position { x: f32, y: f32 }
 //! # struct Velocity { dx: f32, dy: f32 }
@@ -152,30 +153,25 @@
 //! # let mut world = World::default();
 //! # let mut resources = Resources::default();
 //! # resources.insert(Time { elapsed_seconds: 0.0 });
-//! // start defining a new system
-//! let update_positions = SystemBuilder::new("update positions")
-//!     // give it a query - a system may have multiple queries
-//!     .with_query(<(Write<Position>, Read<Velocity>)>::query())
-//!     // give it read access to the time resource
-//!     .read_resource::<Time>()
-//!     // construct the system
-//!     .build(|command_buffer, world, time, query| {
-//!         for (position, velocity) in query.iter_mut(world) {
-//!             position.x += velocity.dx * time.elapsed_seconds;
-//!             position.y += velocity.dy * time.elapsed_seconds;
-//!         }
-//!     });
+//! // a system fn which loops through Position and Velocity components, and reads
+//! // the Time shared resource.
+//! #[system(for_each)]
+//! fn update_positions(pos: &mut Position, vel: &Velocity, #[resource] time: &Time) {
+//!     pos.x += vel.dx * time.elapsed_seconds;
+//!     pos.y += vel.dy * time.elapsed_seconds;
+//! }
 //!
 //! // construct a schedule (you should do this on init)
 //! let mut schedule = Schedule::builder()
-//!     .add_system(update_positions)
+//!     .add_system(update_positions_system())
 //!     .build();
 //!
 //! // run our schedule (you should do this each update)
 //! schedule.execute(&mut world, &mut resources);
+//! # }
 //! ```
 //!
-//! See the [systems module](systems/index.html) for more information.
+//! See the [systems module](systems/index.html) and the [system proc macro](attr.system.html) for more information.
 //!
 //! # Feature Flags
 //!
@@ -184,6 +180,7 @@
 //! * `extended-tuple-impls` - Extends the maximum size of view and component tuples from 8 to 24, at the cost of increased compile times. Off by default.
 //! * `serialize` - Enables the serde serialization module and associated functionality. Enabled by default.
 //! * `crossbeam-events` - Implements the `EventSender` trait for crossbeam `Sender` channels, allowing them to be used for event subscriptions. Enabled by default.
+//! * `codegen` - Enables the `#[system]` procedural macro. Enabled by default.
 
 // implementation modules
 mod internals;

--- a/tests/systems.rs
+++ b/tests/systems.rs
@@ -1,6 +1,7 @@
 use legion::*;
 
 #[test]
+#[cfg(feature = "codegen")]
 fn basic_system() {
     #[system]
     fn hello_world() {
@@ -14,6 +15,7 @@ fn basic_system() {
 }
 
 #[test]
+#[cfg(feature = "codegen")]
 fn for_each_system() {
     #[system(for_each)]
     fn sum(component: &usize, #[resource] total: &mut usize) { *total += component; }

--- a/tests/systems.rs
+++ b/tests/systems.rs
@@ -1,0 +1,31 @@
+use legion::*;
+
+#[test]
+fn basic_system() {
+    #[system]
+    fn hello_world() {
+        println!("hello world");
+    }
+
+    let mut world = World::default();
+    let mut schedule = Schedule::builder().add_system(hello_world_system()).build();
+
+    schedule.execute(&mut world, &mut Resources::default());
+}
+
+#[test]
+fn for_each_system() {
+    #[system(for_each)]
+    fn sum(component: &usize, #[resource] total: &mut usize) { *total += component; }
+
+    let mut world = World::default();
+    world.extend(vec![(1usize, true), (2usize, false), (3usize, true)]);
+
+    let mut resources = Resources::default();
+    resources.insert(0usize);
+
+    let mut schedule = Schedule::builder().add_system(sum_system()).build();
+
+    schedule.execute(&mut world, &mut resources);
+    assert_eq!(*resources.get::<usize>().unwrap(), 6usize);
+}


### PR DESCRIPTION
This PR adds a `#[system]` procedural macro to legion, behind the "codegen" feature flag (enabled by default), which generates the code dealing with manually constructing systems with the `SystemBuilder` API, as discussed in #31. The function maked with the attribute is left as-is, so auto-complete and other IDE tooling continue to function as normal.

To copy and paste the docs for the macro:

## #[system]
Wraps a function in a system, and generates a new function which constructs that system.

There are three types of systems: simple (default), for_each and par_for_each. By default, the system macro will create a new function named `<attributed_fn_name>_system` which can be called to construct the system.

### Examples

By default, the system function is called once when the system runs.

```rust
#[system]
fn hello_world() {
   println!("hello world");
}

Schedule::builder()
    .add_system(hello_world_system())
    .build();
```

The function can request resources with reference parameters marked with the #[resource] attribute.

```rust
#[system]
fn hello_world(#[resource] person: &Person) {
   println!("hello, {}", person.name);
}
```

Systems can also request a world or command buffer.

```rust
#[system]
fn create_entity(world: &mut SubWorld, cmd: &mut CommandBuffer) {
   cmd.push((1usize, false, Person { name: "Jane Doe" }));
}
```

Systems can declare access to component types with the #[read_component] and #[write_component] attributes.

```rust
#[system]
#[read_component(usize)]
#[write_component(bool)]
fn run_query(world: &mut SubWorld) {
    let mut query = <(Read<usize>, Write<bool>)>::query();
    for (a, b) in query.iter_mut(world) {
        println!("{} {}", a, b);
    }
}
```

for_each and par_for_each system types can be used to implement the query for you. References will be interpreted as Read<T> and Write<T>, while options of references (e.g. Option<&Position>) will be interpreted as TryRead<T> and TryWrite<T>. You can request the entity ID via a &Entity parameter.

```rust
#[system(for_each)]
fn update_positions(pos: &mut Position, vel: &Velocity, #[resource] time: &Time) {
    pos.x += vel.x * time.seconds;
}
```

for_each and par_for_each systems can request attitional filters for their query via the #[filter] attribute.

```rust
#[system(for_each)]
#[filter(maybe_changed::<Position>())]
fn update_positions(pos: &mut Position, vel: &Velocity, #[resource] time: &Time) {
    pos.x += vel.x * time.seconds;
}
```

Systems can contain their own state. Add a reference marked with the #[state] parameter to your function. This state will be initialized when you construct the system.

```rust
#[system]
fn stateful(#[state] counter: &mut usize) {
    *counter += 1;
    println!("state: {}", counter);
}

Schedule::builder()
     // initialize state when you construct the system
    .add_system(stateful_system(5usize))
    .build();
```

Systems can contain generic parameters.

```rust
#[system(for_each)]
fn print_component<T: Component + Debug>(component: &T) {
    println!("{:?}", component);
}

Schedule::builder()
     // supply generic parameters when constructing the system
    .add_system(print_component_system::<Position>())
    .build();
```
