### PR TITLE
Allow !Sync resources to be stored in Resources

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2018"
 travis-ci = { repository = "TomGillen/legion", branch = "master" }
 
 [features]
-default = ["par-iter", "serialize", "crossbeam-events"]
+default = ["par-iter", "par-schedule", "serialize", "crossbeam-events"]
+par-schedule = ["rayon"]
 par-iter = ["rayon"]
 extended-tuple-impls = []
 serialize = ["serde", "erased-serde", "uuid/serde"]

--- a/src/internals/query/view/read.rs
+++ b/src/internals/query/view/read.rs
@@ -21,8 +21,10 @@ use std::{any::TypeId, marker::PhantomData, slice::Iter};
 /// Reads a single entity data component type from a chunk.
 #[derive(Derivative, Debug, Copy, Clone)]
 #[derivative(Default(bound = ""))]
-pub struct Read<T>(PhantomData<T>);
+pub struct Read<T>(PhantomData<*const T>);
 
+unsafe impl<T> Send for Read<T> {}
+unsafe impl<T: Sync> Sync for Read<T> {}
 unsafe impl<T> ReadOnly for Read<T> {}
 
 impl<T: Component> DefaultFilter for Read<T> {

--- a/src/internals/query/view/try_read.rs
+++ b/src/internals/query/view/try_read.rs
@@ -21,8 +21,10 @@ use std::{any::TypeId, marker::PhantomData};
 /// Reads a single entity data component type from a chunk.
 #[derive(Derivative, Debug, Copy, Clone)]
 #[derivative(Default(bound = ""))]
-pub struct TryRead<T>(PhantomData<T>);
+pub struct TryRead<T>(PhantomData<*const T>);
 
+unsafe impl<T> Send for TryRead<T> {}
+unsafe impl<T: Sync> Sync for TryRead<T> {}
 unsafe impl<T> ReadOnly for TryRead<T> {}
 
 impl<T: Component> DefaultFilter for TryRead<T> {

--- a/src/internals/query/view/try_write.rs
+++ b/src/internals/query/view/try_write.rs
@@ -21,7 +21,10 @@ use std::{any::TypeId, marker::PhantomData};
 /// Writes a single entity data component type from a chunk.
 #[derive(Derivative, Debug, Copy, Clone)]
 #[derivative(Default(bound = ""))]
-pub struct TryWrite<T>(PhantomData<T>);
+pub struct TryWrite<T>(PhantomData<*const T>);
+
+unsafe impl<T> Send for TryWrite<T> {}
+unsafe impl<T: Sync> Sync for TryWrite<T> {}
 
 impl<T: Component> DefaultFilter for TryWrite<T> {
     type Filter = EntityFilterTuple<TryComponentFilter<T>, Passthrough>;

--- a/src/internals/query/view/try_write.rs
+++ b/src/internals/query/view/try_write.rs
@@ -23,8 +23,8 @@ use std::{any::TypeId, marker::PhantomData};
 #[derivative(Default(bound = ""))]
 pub struct TryWrite<T>(PhantomData<*const T>);
 
-unsafe impl<T> Send for TryWrite<T> {}
-unsafe impl<T: Sync> Sync for TryWrite<T> {}
+unsafe impl<T: Send> Send for TryWrite<T> {}
+unsafe impl<T> Sync for TryWrite<T> {}
 
 impl<T: Component> DefaultFilter for TryWrite<T> {
     type Filter = EntityFilterTuple<TryComponentFilter<T>, Passthrough>;

--- a/src/internals/query/view/write.rs
+++ b/src/internals/query/view/write.rs
@@ -23,8 +23,8 @@ use std::{any::TypeId, marker::PhantomData, slice::Iter};
 #[derivative(Default(bound = ""))]
 pub struct Write<T>(PhantomData<*const T>);
 
-unsafe impl<T> Send for Write<T> {}
-unsafe impl<T: Sync> Sync for Write<T> {}
+unsafe impl<T: Send> Send for Write<T> {}
+unsafe impl<T> Sync for Write<T> {}
 
 impl<T: Component> DefaultFilter for Write<T> {
     type Filter = EntityFilterTuple<ComponentFilter<T>, Passthrough>;

--- a/src/internals/query/view/write.rs
+++ b/src/internals/query/view/write.rs
@@ -21,7 +21,10 @@ use std::{any::TypeId, marker::PhantomData, slice::Iter};
 /// Writes a single mutable entity data component type from a chunk.
 #[derive(Derivative, Debug, Copy, Clone)]
 #[derivative(Default(bound = ""))]
-pub struct Write<T>(PhantomData<T>);
+pub struct Write<T>(PhantomData<*const T>);
+
+unsafe impl<T> Send for Write<T> {}
+unsafe impl<T: Sync> Sync for Write<T> {}
 
 impl<T: Component> DefaultFilter for Write<T> {
     type Filter = EntityFilterTuple<ComponentFilter<T>, Passthrough>;

--- a/src/internals/systems/resources.rs
+++ b/src/internals/systems/resources.rs
@@ -8,14 +8,15 @@ use crate::internals::{
     query::view::{read::Read, write::Write, ReadOnly},
 };
 use downcast_rs::{impl_downcast, Downcast};
-use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{
     any::TypeId,
-    collections::HashMap,
+    cell::UnsafeCell,
+    collections::{hash_map::Entry, HashMap},
     fmt::{Display, Formatter},
     hash::{BuildHasherDefault, Hasher},
     marker::PhantomData,
     ops::{Deref, DerefMut},
+    sync::atomic::AtomicIsize,
 };
 
 /// Unique ID for a resource.
@@ -54,8 +55,8 @@ impl Display for ResourceTypeId {
 }
 
 /// Blanket trait for resource types.
-pub trait Resource: 'static + Downcast + Send + Sync {}
-impl<T> Resource for T where T: 'static + Send + Sync {}
+pub trait Resource: 'static + Downcast {}
+impl<T> Resource for T where T: 'static {}
 impl_downcast!(Resource);
 
 /// Trait which is implemented for tuples of resources and singular resources. This abstracts
@@ -85,7 +86,7 @@ impl_downcast!(Resource);
 /// }
 ///
 /// ```
-pub trait ResourceSet<'a>: Send + Sync {
+pub trait ResourceSet<'a> {
     /// The resource reference returned during a fetch.
     type Result: 'a;
 
@@ -93,12 +94,12 @@ pub trait ResourceSet<'a>: Send + Sync {
     ///
     /// # Safety
     /// It is up to the end user to validate proper mutability rules across the resources being accessed.
-    unsafe fn fetch_unchecked(resources: &'a Resources) -> Self::Result;
+    unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self::Result;
 
     /// Fetches all defined resources.
     fn fetch_mut(resources: &'a mut Resources) -> Self::Result {
         // safe because mutable borrow ensures exclusivity
-        unsafe { Self::fetch_unchecked(resources) }
+        unsafe { Self::fetch_unchecked(&resources.internal) }
     }
 
     /// Fetches all defined resources.
@@ -106,33 +107,31 @@ pub trait ResourceSet<'a>: Send + Sync {
     where
         Self: ReadOnly,
     {
-        unsafe { Self::fetch_unchecked(resources) }
+        unsafe { Self::fetch_unchecked(&resources.internal) }
     }
 }
 
 impl<'a> ResourceSet<'a> for () {
     type Result = ();
 
-    unsafe fn fetch_unchecked(_: &Resources) {}
+    unsafe fn fetch_unchecked(_: &UnsafeResources) -> Self::Result {}
 }
 
 impl<'a, T: Resource> ResourceSet<'a> for Read<T> {
     type Result = Fetch<'a, T>;
 
-    unsafe fn fetch_unchecked(resources: &'a Resources) -> Self::Result {
-        resources
-            .get::<T>()
-            .unwrap_or_else(|| panic!("Failed to fetch resource!: {}", std::any::type_name::<T>()))
+    unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self::Result {
+        let type_id = &ResourceTypeId::of::<T>();
+        resources.get(&type_id).unwrap().get::<T>().unwrap()
     }
 }
 
 impl<'a, T: Resource> ResourceSet<'a> for Write<T> {
     type Result = FetchMut<'a, T>;
 
-    unsafe fn fetch_unchecked(resources: &'a Resources) -> Self::Result {
-        resources
-            .get_mut::<T>()
-            .unwrap_or_else(|| panic!("Failed to fetch resource!: {}", std::any::type_name::<T>()))
+    unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self::Result {
+        let type_id = &ResourceTypeId::of::<T>();
+        resources.get(&type_id).unwrap().get_mut::<T>().unwrap()
     }
 }
 
@@ -153,7 +152,7 @@ macro_rules! impl_resource_tuple {
         {
             type Result = ($( $ty::Result, )*);
 
-            unsafe fn fetch_unchecked(resources: &'a Resources) -> Self::Result {
+            unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self::Result {
                 ($( $ty::fetch_unchecked(resources), )*)
             }
         }
@@ -168,22 +167,15 @@ resource_tuple!(A, B, C, D, E, F, G, H);
 
 /// Ergonomic wrapper type which contains a `Ref` type.
 pub struct Fetch<'a, T: Resource> {
-    inner: RwLockReadGuard<'a, Box<dyn Resource>>,
-    _marker: PhantomData<T>,
+    state: &'a AtomicIsize,
+    inner: &'a T,
 }
 
 impl<'a, T: Resource> Deref for Fetch<'a, T> {
     type Target = T;
 
     #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.inner.downcast_ref::<T>().unwrap_or_else(|| {
-            panic!(
-                "Unable to downcast the resource!: {}",
-                std::any::type_name::<T>()
-            )
-        })
-    }
+    fn deref(&self) -> &Self::Target { self.inner }
 }
 
 impl<'a, T: 'a + Resource + std::fmt::Debug> std::fmt::Debug for Fetch<'a, T> {
@@ -192,35 +184,29 @@ impl<'a, T: 'a + Resource + std::fmt::Debug> std::fmt::Debug for Fetch<'a, T> {
     }
 }
 
+impl<'a, T: Resource> Drop for Fetch<'a, T> {
+    fn drop(&mut self) {
+        self.state
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Ergonomic wrapper type which contains a `RefMut` type.
 pub struct FetchMut<'a, T: Resource> {
-    inner: RwLockWriteGuard<'a, Box<dyn Resource>>,
-    _marker: PhantomData<T>,
+    state: &'a AtomicIsize,
+    inner: &'a mut T,
 }
+
 impl<'a, T: 'a + Resource> Deref for FetchMut<'a, T> {
     type Target = T;
 
     #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.inner.downcast_ref::<T>().unwrap_or_else(|| {
-            panic!(
-                "Unable to downcast the resource!: {}",
-                std::any::type_name::<T>()
-            )
-        })
-    }
+    fn deref(&self) -> &Self::Target { &*self.inner }
 }
 
 impl<'a, T: 'a + Resource> DerefMut for FetchMut<'a, T> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut T {
-        self.inner.downcast_mut::<T>().unwrap_or_else(|| {
-            panic!(
-                "Unable to downcast the resource!: {}",
-                std::any::type_name::<T>()
-            )
-        })
-    }
+    fn deref_mut(&mut self) -> &mut T { &mut *self.inner }
 }
 
 impl<'a, T: 'a + Resource + std::fmt::Debug> std::fmt::Debug for FetchMut<'a, T> {
@@ -229,28 +215,175 @@ impl<'a, T: 'a + Resource + std::fmt::Debug> std::fmt::Debug for FetchMut<'a, T>
     }
 }
 
+impl<'a, T: Resource> Drop for FetchMut<'a, T> {
+    fn drop(&mut self) {
+        self.state
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+pub struct ResourceCell {
+    data: UnsafeCell<Box<dyn Resource>>,
+    borrow_state: AtomicIsize,
+}
+
+impl ResourceCell {
+    fn new(resource: Box<dyn Resource>) -> Self {
+        Self {
+            data: UnsafeCell::new(resource),
+            borrow_state: AtomicIsize::new(0),
+        }
+    }
+
+    fn into_inner(self) -> Box<dyn Resource> { self.data.into_inner() }
+
+    pub unsafe fn get<T: Resource>(&self) -> Option<Fetch<'_, T>> {
+        loop {
+            let read = self.borrow_state.load(std::sync::atomic::Ordering::SeqCst);
+            if read < 0 {
+                panic!(
+                    "resource already borrowed as mutable: {}",
+                    std::any::type_name::<T>()
+                );
+            }
+
+            if self.borrow_state.compare_and_swap(
+                read,
+                read + 1,
+                std::sync::atomic::Ordering::SeqCst,
+            ) == read
+            {
+                break;
+            }
+        }
+
+        let resource = self.data.get().as_ref().and_then(|r| r.downcast_ref::<T>());
+        if let Some(resource) = resource {
+            Some(Fetch {
+                state: &self.borrow_state,
+                inner: resource,
+            })
+        } else {
+            self.borrow_state
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            None
+        }
+    }
+
+    pub unsafe fn get_mut<T: Resource>(&self) -> Option<FetchMut<'_, T>> {
+        let borrowed =
+            self.borrow_state
+                .compare_and_swap(0, -1, std::sync::atomic::Ordering::SeqCst);
+        match borrowed {
+            0 => {
+                let resource = self.data.get().as_mut().and_then(|r| r.downcast_mut::<T>());
+                if let Some(resource) = resource {
+                    Some(FetchMut {
+                        state: &self.borrow_state,
+                        inner: resource,
+                    })
+                } else {
+                    self.borrow_state
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    None
+                }
+            }
+            x if x < 0 => panic!(
+                "resource already borrowed as mutable: {}",
+                std::any::type_name::<T>()
+            ),
+            _ => panic!(
+                "resource already borrowed as immutable: {}",
+                std::any::type_name::<T>()
+            ),
+        }
+    }
+}
+
+/// A container for resources which performs runtime borrow checking
+/// but _does not_ ensure that `!Sync` resources aren't accessed across threads.
+#[derive(Default)]
+pub struct UnsafeResources {
+    map: HashMap<ResourceTypeId, ResourceCell, BuildHasherDefault<ComponentTypeIdHasher>>,
+}
+
+unsafe impl Send for UnsafeResources {}
+unsafe impl Sync for UnsafeResources {}
+
+impl UnsafeResources {
+    fn contains(&self, type_id: &ResourceTypeId) -> bool { self.map.contains_key(type_id) }
+
+    /// # Safety
+    /// Resources which are `!Sync` or `!Send` must be retrieved or inserted only on the main thread.
+    unsafe fn entry(&mut self, type_id: ResourceTypeId) -> Entry<ResourceTypeId, ResourceCell> {
+        self.map.entry(type_id)
+    }
+
+    /// # Safety
+    /// Resources which are `!Send` must be retrieved or inserted only on the main thread.
+    unsafe fn insert<T: Resource>(&mut self, resource: T) {
+        self.map.insert(
+            ResourceTypeId::of::<T>(),
+            ResourceCell::new(Box::new(resource)),
+        );
+    }
+
+    /// # Safety
+    /// Resources which are `!Send` must be retrieved or inserted only on the main thread.
+    unsafe fn remove(&mut self, type_id: &ResourceTypeId) -> Option<Box<dyn Resource>> {
+        self.map.remove(type_id).map(|cell| cell.into_inner())
+    }
+
+    /// # Safety
+    /// Resources which are `!Sync` must be retrieved or inserted only on the main thread.
+    unsafe fn get(&self, type_id: &ResourceTypeId) -> Option<&ResourceCell> {
+        self.map.get(type_id)
+    }
+
+    /// # Safety
+    /// Resources which are `!Sync` must be retrieved or inserted only on the main thread.
+    unsafe fn merge(&mut self, mut other: Self) {
+        // Merge resources, retaining our local ones but moving in any non-existant ones
+        for resource in other.map.drain() {
+            self.map.entry(resource.0).or_insert(resource.1);
+        }
+    }
+}
+
 /// Resources container. Shared resources stored here can be retrieved in systems.
 #[derive(Default)]
 pub struct Resources {
-    storage: HashMap<
-        ResourceTypeId,
-        RwLock<Box<dyn Resource>>,
-        BuildHasherDefault<ComponentTypeIdHasher>,
-    >,
+    internal: UnsafeResources,
+    // marker to make `Resources` !Send and !Sync
+    _not_send_sync: PhantomData<*const u8>,
 }
 
 impl Resources {
+    pub(crate) fn internal(&self) -> &UnsafeResources { &self.internal }
+
+    /// Creates an accessor to resources which are Send and Sync, which itself can be sent
+    /// between threads.
+    pub fn sync(&mut self) -> SyncResources {
+        SyncResources {
+            internal: &self.internal,
+        }
+    }
+
     /// Returns `true` if type `T` exists in the store. Otherwise, returns `false`.
     pub fn contains<T: Resource>(&self) -> bool {
-        self.storage.contains_key(&ResourceTypeId::of::<T>())
+        self.internal.contains(&ResourceTypeId::of::<T>())
     }
 
     /// Inserts the instance of `T` into the store. If the type already exists, it will be silently
     /// overwritten. If you would like to retain the instance of the resource that already exists,
     /// call `remove` first to retrieve it.
     pub fn insert<T: Resource>(&mut self, value: T) {
-        self.storage
-            .insert(ResourceTypeId::of::<T>(), RwLock::new(Box::new(value)));
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
+        unsafe {
+            self.internal.insert(value);
+        }
     }
 
     /// Removes the type `T` from this store if it exists.
@@ -258,14 +391,17 @@ impl Resources {
     /// # Returns
     /// If the type `T` was stored, the inner instance of `T is returned. Otherwise, `None`.
     pub fn remove<T: Resource>(&mut self) -> Option<T> {
-        Some(
-            *self
-                .storage
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
+        unsafe {
+            let resource = self
+                .internal
                 .remove(&ResourceTypeId::of::<T>())?
-                .into_inner()
                 .downcast::<T>()
-                .ok()?,
-        )
+                .ok()?;
+            Some(*resource)
+        }
     }
 
     /// Retrieve an immutable reference to  `T` from the store if it exists. Otherwise, return `None`.
@@ -273,32 +409,36 @@ impl Resources {
     /// # Panics
     /// Panics if the resource is already borrowed mutably.
     pub fn get<T: Resource>(&self) -> Option<Fetch<'_, T>> {
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
         let type_id = &ResourceTypeId::of::<T>();
-        Some(Fetch {
-            inner: self.storage.get(type_id)?.try_read().unwrap_or_else(|| {
-                panic!("resource {:?} already borrowed mutably elsewhere", type_id)
-            }),
-            _marker: PhantomData,
-        })
+        unsafe { self.internal.get(&type_id)?.get::<T>() }
     }
 
     /// Retrieve a mutable reference to  `T` from the store if it exists. Otherwise, return `None`.
     pub fn get_mut<T: Resource>(&self) -> Option<FetchMut<'_, T>> {
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
         let type_id = &ResourceTypeId::of::<T>();
-        Some(FetchMut {
-            inner: self
-                .storage
-                .get(type_id)?
-                .try_write()
-                .unwrap_or_else(|| panic!("resource {:?} already borrowed elsewhere", type_id)),
-            _marker: PhantomData,
-        })
+        unsafe { self.internal.get(&type_id)?.get_mut::<T>() }
     }
 
     /// Attempts to retrieve an immutable reference to `T` from the store. If it does not exist,
     /// the closure `f` is called to construct the object and it is then inserted into the store.
     pub fn get_or_insert_with<T: Resource, F: FnOnce() -> T>(&mut self, f: F) -> Fetch<'_, T> {
-        self.get_or_insert((f)())
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
+        let type_id = ResourceTypeId::of::<T>();
+        unsafe {
+            self.internal
+                .entry(type_id)
+                .or_insert_with(|| ResourceCell::new(Box::new((f)())))
+                .get()
+                .unwrap()
+        }
     }
 
     /// Attempts to retrieve a mutable reference to `T` from the store. If it does not exist,
@@ -307,41 +447,29 @@ impl Resources {
         &mut self,
         f: F,
     ) -> FetchMut<'_, T> {
-        self.get_mut_or_insert((f)())
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
+        let type_id = ResourceTypeId::of::<T>();
+        unsafe {
+            self.internal
+                .entry(type_id)
+                .or_insert_with(|| ResourceCell::new(Box::new((f)())))
+                .get_mut()
+                .unwrap()
+        }
     }
 
     /// Attempts to retrieve an immutable reference to `T` from the store. If it does not exist,
     /// the provided value is inserted and then a reference to it is returned.
     pub fn get_or_insert<T: Resource>(&mut self, value: T) -> Fetch<'_, T> {
-        let type_id = ResourceTypeId::of::<T>();
-        Fetch {
-            inner: self
-                .storage
-                .entry(type_id)
-                .or_insert_with(|| RwLock::new(Box::new(value)))
-                .try_read()
-                .unwrap_or_else(|| {
-                    panic!("resource {:?} already borrowed mutably elsewhere", type_id)
-                }),
-            _marker: Default::default(),
-        }
+        self.get_or_insert_with(|| value)
     }
 
     /// Attempts to retrieve a mutable reference to `T` from the store. If it does not exist,
     /// the provided value is inserted and then a reference to it is returned.
     pub fn get_mut_or_insert<T: Resource>(&mut self, value: T) -> FetchMut<'_, T> {
-        let type_id = ResourceTypeId::of::<T>();
-        FetchMut {
-            inner: self
-                .storage
-                .entry(type_id)
-                .or_insert_with(|| RwLock::new(Box::new(value)))
-                .try_write()
-                .unwrap_or_else(|| {
-                    panic!("resource {:?} already borrowed mutably elsewhere", type_id)
-                }),
-            _marker: Default::default(),
-        }
+        self.get_mut_or_insert_with(|| value)
     }
 
     /// Attempts to retrieve an immutable reference to `T` from the store. If it does not exist,
@@ -349,18 +477,7 @@ impl Resources {
     ///
     /// `T` must implement `Default` for this method.
     pub fn get_or_default<T: Resource + Default>(&mut self) -> Fetch<'_, T> {
-        let type_id = ResourceTypeId::of::<T>();
-        Fetch {
-            inner: self
-                .storage
-                .entry(type_id)
-                .or_insert_with(|| RwLock::new(Box::new(T::default())))
-                .try_read()
-                .unwrap_or_else(|| {
-                    panic!("resource {:?} already borrowed mutably elsewhere", type_id)
-                }),
-            _marker: Default::default(),
-        }
+        self.get_or_insert_with(T::default)
     }
 
     /// Attempts to retrieve a mutable reference to `T` from the store. If it does not exist,
@@ -368,28 +485,46 @@ impl Resources {
     ///
     /// `T` must implement `Default` for this method.
     pub fn get_mut_or_default<T: Resource + Default>(&mut self) -> FetchMut<'_, T> {
-        let type_id = ResourceTypeId::of::<T>();
-        FetchMut {
-            inner: self
-                .storage
-                .entry(type_id)
-                .or_insert_with(|| RwLock::new(Box::new(T::default())))
-                .try_write()
-                .unwrap_or_else(|| {
-                    panic!("resource {:?} already borrowed mutably elsewhere", type_id)
-                }),
-            _marker: Default::default(),
-        }
+        self.get_mut_or_insert_with(T::default)
     }
 
     /// Performs merging of two resource storages, which occurs during a world merge.
     /// This merge will retain any already-existant resources in the local world, while moving any
     /// new resources from the source world into this one, consuming the resources.
-    pub fn merge(&mut self, mut other: Resources) {
-        // Merge resources, retaining our local ones but moving in any non-existant ones
-        for resource in other.storage.drain() {
-            self.storage.entry(resource.0).or_insert(resource.1);
+    pub fn merge(&mut self, other: Resources) {
+        // safety:
+        // this type is !Send and !Sync, and so can only be accessed from the thread which
+        // owns the resources collection
+        unsafe {
+            self.internal.merge(other.internal);
         }
+    }
+}
+
+/// A resource collection which is `Send` and `Sync`, but which only allows access to resources
+/// which are `Sync`.
+pub struct SyncResources<'a> {
+    internal: &'a UnsafeResources,
+}
+
+impl<'a> SyncResources<'a> {
+    /// Retrieve an immutable reference to  `T` from the store if it exists. Otherwise, return `None`.
+    ///
+    /// # Panics
+    /// Panics if the resource is already borrowed mutably.
+    pub fn get<T: Resource + Sync>(&self) -> Option<Fetch<'_, T>> {
+        // safety:
+        // only resources which are Sync can be accessed, and so are safe to access from any thread
+        let type_id = &ResourceTypeId::of::<T>();
+        unsafe { self.internal.get(&type_id)?.get::<T>() }
+    }
+
+    /// Retrieve a mutable reference to  `T` from the store if it exists. Otherwise, return `None`.
+    pub fn get_mut<T: Resource + Sync>(&self) -> Option<FetchMut<'_, T>> {
+        // safety:
+        // only resources which are Sync can be accessed, and so are safe to access from any thread
+        let type_id = &ResourceTypeId::of::<T>();
+        unsafe { self.internal.get(&type_id)?.get_mut::<T>() }
     }
 }
 
@@ -407,6 +542,10 @@ mod tests {
             value: String,
         }
 
+        struct NotSync {
+            ptr: *const u8,
+        }
+
         let mut resources = Resources::default();
         resources.insert(TestOne {
             value: "one".to_string(),
@@ -416,11 +555,16 @@ mod tests {
             value: "two".to_string(),
         });
 
+        resources.insert(NotSync {
+            ptr: std::ptr::null(),
+        });
+
         assert_eq!(resources.get::<TestOne>().unwrap().value, "one");
         assert_eq!(resources.get::<TestTwo>().unwrap().value, "two");
+        assert_eq!(resources.get::<NotSync>().unwrap().ptr, std::ptr::null());
 
         // test re-ownership
         let owned = resources.remove::<TestTwo>();
-        assert_eq!(owned.unwrap().value, "two")
+        assert_eq!(owned.unwrap().value, "two");
     }
 }

--- a/src/internals/systems/schedule.rs
+++ b/src/internals/systems/schedule.rs
@@ -149,12 +149,16 @@ impl Executor {
                 HashMap::<ComponentTypeId, usize>::with_capacity_and_hasher(64, Default::default());
 
             for (i, system) in systems.iter().enumerate() {
-                let span = span!(
-                    Level::TRACE,
-                    "Building system dependencies",
-                    system = %system.name(),
-                    index = i,
-                );
+                let span = if let Some(name) = system.name() {
+                    span!(
+                        Level::TRACE,
+                        "Building system dependencies",
+                        system = %name,
+                        index = i,
+                    )
+                } else {
+                    span!(Level::TRACE, "building system dependencies", index = i)
+                };
                 let _guard = span.enter();
 
                 let (read_res, read_comp) = system.reads();

--- a/src/internals/systems/system.rs
+++ b/src/internals/systems/system.rs
@@ -2,7 +2,7 @@
 
 use super::{
     command::CommandBuffer,
-    resources::{Resource, ResourceSet, ResourceTypeId, Resources},
+    resources::{Resource, ResourceSet, ResourceTypeId, UnsafeResources},
     schedule::Runnable,
 };
 use crate::internals::{
@@ -109,6 +109,10 @@ impl<T: Into<Cow<'static, str>>> From<T> for SystemId {
     }
 }
 
+struct ResourceMarker<T>(PhantomData<*const T>);
+unsafe impl<T: Send> Send for ResourceMarker<T> {}
+unsafe impl<T: Sync> Sync for ResourceMarker<T> {}
+
 /// The concrete type which contains the system closure provided by the user.  This struct should
 /// not be instantiated directly, and instead should be created using `SystemBuilder`.
 ///
@@ -121,7 +125,7 @@ impl<T: Into<Cow<'static, str>>> From<T> for SystemId {
 /// on each `run` call, wrapping the world and providing the set to the user in their closure.
 pub struct System<R, Q, F> {
     name: SystemId,
-    _resources: PhantomData<R>,
+    _resources: ResourceMarker<R>,
     queries: Q,
     run_fn: F,
     archetypes: ArchetypeAccess,
@@ -165,7 +169,7 @@ where
         self.command_buffer.get_mut(&world)
     }
 
-    unsafe fn run_unsafe(&mut self, world: &World, resources: &Resources) {
+    unsafe fn run_unsafe(&mut self, world: &World, resources: &UnsafeResources) {
         let span = span!(Level::INFO, "System", system = %self.name);
         let _guard = span.enter();
 
@@ -178,7 +182,7 @@ where
         // As the fetch struct is created on the stack here, and the resources it is holding onto is a parameter to this function,
         // we know for certain that the lifetime of the fetch struct (which constrains the lifetime of the resource the system sees)
         // must be shorter than the lifetime of the resource.
-        let resources_static = std::mem::transmute::<_, &'static Resources>(resources);
+        let resources_static = &*(resources as *const UnsafeResources);
         let mut resources = R::fetch_unchecked(resources_static);
 
         let queries = &mut self.queries;
@@ -405,7 +409,7 @@ where
         run_fn: F,
     ) -> System<<R as ConsFlatten>::Output, <Q as ConsFlatten>::Output, F>
     where
-        <R as ConsFlatten>::Output: for<'a> ResourceSet<'a> + Send + Sync,
+        <R as ConsFlatten>::Output: for<'a> ResourceSet<'a>,
         <Q as ConsFlatten>::Output: QuerySet,
         F: FnMut(
             &mut CommandBuffer,
@@ -417,7 +421,7 @@ where
         System {
             name: self.name,
             run_fn,
-            _resources: PhantomData::<<R as ConsFlatten>::Output>,
+            _resources: ResourceMarker(PhantomData),
             queries: self.queries.flatten(),
             archetypes: if self.access_all_archetypes {
                 ArchetypeAccess::All

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -2,7 +2,9 @@
 
 pub use crate::internals::systems::{
     command::{CommandBuffer, WorldWritable},
-    resources::{Fetch, Resource, ResourceSet, ResourceTypeId, Resources},
-    schedule::{Builder, Executor, Runnable, Schedulable, Schedule, Step},
+    resources::{
+        Fetch, Resource, ResourceSet, ResourceTypeId, Resources, SyncResources, UnsafeResources,
+    },
+    schedule::{Builder, Executor, ParallelRunnable, Runnable, Schedule, Step},
     system::{QuerySet, System, SystemAccess, SystemBuilder, SystemFn, SystemId},
 };


### PR DESCRIPTION
Resources which are !Sync can now be stored inside Resources collections. Systems which attempt to access such resources will themselves be marked as !Sync and cannot be scheduled via `add_system`, but must be scheduled as thread-local via `add_thread_local`.

This is a breaking change as `Resources` is now no longer `Send` or `Sync`, as it may own resources which themselves need to stay on the main thread.