### PR TITLE
Fix compilation to wasm: the Uuid::new_v4() function is not found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ par-iter = ["rayon"]
 extended-tuple-impls = []
 serialize = ["serde", "erased-serde", "uuid/serde"]
 crossbeam-events = ["crossbeam-channel"]
+stdweb = ["uuid/stdweb"]
+wasm-bindgen = ["uuid/wasm-bindgen"]
 
 [dependencies]
 smallvec = "1.4"


### PR DESCRIPTION
Legion uses the Uuid::new_v4 function in `src/internals/entity.rs` and it
correctly depends on the uuid create with feature 'v4' enabled. However,
for wasm targets you must additionally enable either the stdweb or
wasm-bindgen feature on that crate: https://github.com/uuid-rs/uuid#dependencies

Therefore, re-export those features so they may be enabled by downstream
libraries/binaries that target wasm and use this crate.