### PR TITLE
Re-export legion_codegen so it's visible in crates that re-export legion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,9 @@ pub use crate::{
 };
 
 #[cfg(feature = "codegen")]
+pub use legion_codegen;
+
+#[cfg(feature = "codegen")]
 pub use legion_codegen::system;
 
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
Ran into #178 myself and seemed an easy fix. I couldn't find any contributing guidelines, hope this is ok?